### PR TITLE
[cmake] fix finding non libEGL.so EGL libraries

### DIFF
--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -7,7 +7,6 @@
 #  EGL_DEFINITIONS - Compiler switches required for using EGL.
 #
 # Copyright (C) 2012 Intel Corporation. All rights reserved.
-# Copyright (C) 2017 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,17 +35,27 @@ find_package(PkgConfig)
 pkg_check_modules(PC_EGL egl)
 
 if (PC_EGL_FOUND)
+    set(EGL_CFLAFS ${PC_EGL_CFLAGS})
     set(EGL_DEFINITIONS ${PC_EGL_CFLAGS_OTHER})
+    set(EGL_NAMES ${PC_EGL_LIBRARIES})
+    foreach (_library ${EGL_NAMES})
+        find_library(EGL_LIBRARIES_${_library} ${_library}
+	    HINTS ${PC_EGL_LIBDIR} ${PC_EGL_LIBRARY_DIRS}
+        )
+        set(EGL_LIBRARIES ${EGL_LIBRARIES} ${EGL_LIBRARIES_${_library}})
+    endforeach ()
+else ()
+    set(EGL_NAMES ${EGL_NAMES} egl EGL)
+    find_library(EGL_LIBRARIES NAMES ${EGL_NAMES}
+        HINTS ${PC_EGL_LIBDIR} ${PC_EGL_LIBRARY_DIRS}
+    )
 endif ()
 
-find_path(EGL_INCLUDE_DIRS NAMES EGL/eglplatform.h
+find_path(EGL_INCLUDE_DIRS NAMES EGL/egl.h
     HINTS ${PC_EGL_INCLUDEDIR} ${PC_EGL_INCLUDE_DIRS}
 )
 
-set(EGL_NAMES ${EGL_NAMES} egl EGL)
-find_library(EGL_LIBRARIES NAMES ${EGL_NAMES}
-    HINTS ${PC_EGL_LIBDIR} ${PC_EGL_LIBRARY_DIRS}
-)
+set(EGL_INCLUDE_DIRS ${PC_EGL_INCLUDE_DIRS} CACHE FILEPATH "FIXME")
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(EGL DEFAULT_MSG EGL_INCLUDE_DIRS EGL_LIBRARIES)


### PR DESCRIPTION
the current find script had trouble finding EGL libs on our platforms, so I synced the one used in other WPE projects and this one works fine for all platforms.  