### PR TITLE
 meson: Import build definitions for Meson

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+---
+
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Debian Packages
+        run: |
+          sudo apt update
+          sudo apt install -y cmake flex libjson-glib-dev libxkbcommon-dev \
+            libegl1-mesa-dev libxml2-dev libxslt1-dev libyaml-dev llvm-dev \
+            libclang-dev libglib2.0-dev ninja-build
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Python Package Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install Python Packages
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson
+      - name: Meson - Configure
+        run: |
+          mkdir -p _work/meson
+          meson _work/meson/build --prefix /usr -Dbuild-docs=true
+      - name: Meson - Build
+        run: |
+          ninja -C _work/meson/build
+      - name: Meson - Install
+        run: |
+          DESTDIR="$(pwd)/_work/meson/prefix" ninja -C _work/meson/build install
+          nm -D _work/meson/build/libwpe-1.0.so | sort -u > _work/meson/symbols
+          (cd _work/meson/prefix && find lib -type f | sort) > _work/meson/files
+      - name: Meson - Archive Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-meson
+          path: _work/meson/prefix
+      - name: CMake - Configure
+        run: |
+          mkdir -p _work/cmake/build && cd $_
+          cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_DOCS=ON ../../..
+      - name: CMake - Build
+        run: |
+          make -C _work/cmake/build -j$(nproc)
+      - name: CMake - Install
+        run: |
+          DESTDIR="$(pwd)/_work/cmake/prefix" make -C _work/cmake/build install
+          nm -D _work/cmake/build/libwpe-1.0.so | sort -u > _work/cmake/symbols
+          (cd _work/cmake/prefix && find lib -type f | sort) > _work/cmake/files
+      - name: CMake - Archive Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-cmake
+          path: _work/cmake/prefix
+      - name: Check Installations
+        run: |
+          diff -u _work/{cmake,meson}/files
+          diff -u _work/{cmake,meson}/symbols
+          diff -Naur _work/{cmake,meson}/prefix/usr/include/

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,145 @@
+project('libwpe', 'cpp', 'c',
+	meson_version: '>=0.49',
+	default_options: [
+		'b_ndebug=if-release',
+		'c_std=c99',
+		'cpp_eh=none',
+		'cpp_std=c++11',
+	],
+	license: 'BSD-2-Clause',
+	version: '1.7.0',
+)
+
+# This refers to the API level provided. This is modified only with major,
+# breaking changes, which need modifications in programs using the library
+# before they can be compiled again.
+api_version = '1.0'
+
+# Before making a release, the LT_VERSION string should be modified.
+# The string is of the form [C, R, A].
+# - If interfaces have been changed or added, but binary compatibility has
+#   been preserved, change to [C+1, 0, A+1].
+# - If binary compatibility has been broken (eg removed or changed interfaces)
+#   change to [C+1, 0, 0]
+# - If the interface is the same as the previous version, use [C, R+1, A].
+soversion = [5, 0, 4]
+
+# Split the *project* version into its components.
+version_info = meson.project_version().split('.')
+version_info = {
+	'PROJECT_VERSION_MAJOR': version_info[0],
+	'PROJECT_VERSION_MINOR': version_info[1],
+	'PROJECT_VERSION_PATCH': version_info[2],
+}
+
+# Mangle [C, R, A] into an actual usable *soversion*.
+soversion_major = soversion[0] - soversion[2]  # Current-Age
+soversion_minor = soversion[2]  # Age
+soversion_micro = soversion[1]  # Revision
+soversion = '@0@.@1@.@2@'.format(soversion_major, soversion_minor, soversion_micro)
+
+add_project_arguments('-DWPE_COMPILATION=1', language: ['c', 'cpp'])
+
+# Switch to the 'cpp_rtti=false' default option when updating to Meson 0.53 or newer, see
+# https://mesonbuild.com/FAQ.html#how-do-i-disable-exceptions-and-rtti-in-my-c-project
+add_project_arguments(
+	meson.get_compiler('cpp').get_supported_arguments(['-fno-rtti']),
+	language: 'cpp'
+)
+
+default_backend = get_option('default-backend').strip()
+if default_backend != ''
+	add_project_arguments('-DWPE_BACKEND="@0@"'.format(default_backend), language: ['c', 'cpp'])
+endif
+
+dependencies = [
+	dependency('xkbcommon'),
+]
+
+cc = meson.get_compiler('c')
+if not cc.has_header('EGL/eglplatform.h')
+	dependencies += dependency('egl')
+endif
+
+if not cc.has_function('dlopen')
+	dependencies += cc.find_library('dl')
+endif
+
+libwpe = library('wpe-' + api_version,
+	'src/input.c',
+	'src/key-unicode.c',
+	'src/loader.c',
+	'src/pasteboard.c',
+	'src/pasteboard-generic.cpp',
+	'src/pasteboard-noop.cpp',
+	'src/renderer-backend-egl.c',
+	'src/renderer-host.c',
+	'src/version.c',
+	'src/view-backend.c',
+	install: true,
+	dependencies: dependencies,
+	version: soversion,
+	soversion: soversion_major,
+	include_directories: 'include',
+)
+
+api_headers = [
+	'include/wpe/export.h',
+	'include/wpe/input.h',
+	'include/wpe/keysyms.h',
+	'include/wpe/loader.h',
+	'include/wpe/pasteboard.h',
+	'include/wpe/renderer-backend-egl.h',
+	'include/wpe/renderer-host.h',
+	'include/wpe/view-backend.h',
+	'include/wpe/wpe-egl.h',
+	'include/wpe/wpe.h',
+
+	# Generated API headers.
+	configure_file(
+		input: 'include/wpe/version.h.cmake',
+		output: 'version.h',
+		configuration: version_info,
+	),
+	configure_file(
+		input: 'include/wpe/version-deprecated.h.cmake',
+		output: 'version-deprecated.h',
+		configuration: version_info,
+	),
+]
+install_headers(api_headers,
+	subdir: join_paths('wpe-' + api_version, 'wpe'),
+)
+
+import('pkgconfig').generate(
+	description: 'The wpe library',
+	name: 'wpe-' + api_version,
+	subdirs: 'wpe-' + api_version,
+	libraries: libwpe,
+	version: meson.project_version(),
+)
+
+if get_option('build-docs')
+	hotdoc = import('hotdoc')
+	assert(hotdoc.has_extensions('c-extension'),
+		'The HotDoc C extension is required.'
+	)
+	libwpe_doc = hotdoc.generate_doc(meson.project_name(),
+		project_version: api_version,
+		dependencies: dependencies,
+		index: 'docs/index.md',
+		sitemap: 'docs/sitemap.txt',
+		console: true,
+		install: true,
+		build_by_default: true,
+		c_smart_index: true,
+		c_sources: api_headers,
+		c_include_directories: [
+			include_directories('include'),
+			meson.current_build_dir()
+		],
+		# The space here is relevant, see
+		# https://github.com/mesonbuild/meson/issues/5800#issuecomment-552198354
+		extra_c_flags: [' -DWPE_COMPILATION=1'],
+	)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,10 @@
+option('default-backend',
+	type: 'string',
+	value: '',
+	description: 'Name of the backend library to load, instead of libWPEBackend-default.so'
+)
+option('build-docs',
+	type: 'boolean',
+	value: false,
+	description: 'Build reference documentation (needs HotDoc)'
+)


### PR DESCRIPTION
This replicates the CMake build system without replacing it, the main difference being that build options are passed differently:

* `-DBUILD_DOCS=ON` becomes `-Dbuild-docs=true`
* `-DWPE_BACKEND=`…` becomes `-Ddefault-backend=…`

Of course, the rest of CMake vs. Meson differences apply. There are some niceties and advantages over CMake, like being trivial to do unified builds (with `--unity`), compiler warnings being enabled by default (controllable with `--warnlevel` and `--werror`), being able to disable C++ exception handling with project options, first grade support for `pkg-config` dependencies, and being able to run `scan-build` without manual configuration (just run `ninja scan-build`), to name a few.

**Note**: <del>Currently building the documentation does not work due to  https://github.com/mesonbuild/meson/issues/5800</del>

----

<del>I did this just as a proof of concept to see what it would take to migrate a CMake project to Meson, now that Buildroot has some support upstream for Meson — Feel free to skip merging this PR, or defer it for later, but personally</del> I find Meson the less annoying of the existing configuration/build systems so my *personal* opinion is that this is a change for better :wink: 