### PR TITLE
CI: Initial configuration to use Circle-CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,26 +7,19 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Prepare
+          name: Build
           command: |
             rm -rf _p output
             mkdir -p _p/src/_build output
             curl -sLo _p/PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=libwpe-git'
             ln -sf "$(pwd)" _p/src/libwpe-git
             cd _p
-      - run:
-          name: Build
-          command: |
-            cd _p
             makepkg --skipinteg --nosign --noextract --force --nocolor
-      - run:
-          name: Check
-          command: |
-            cd _p
             while read -r pkg ; do
-              echo "=== $(basename "${pkg}") ==="
+              printf '\n=== %s ===\n\n' "$(basename "${pkg}")"
               namcap "${pkg}"
               ln "${pkg}" ../output/
             done < <(makepkg --packagelist) | tee ../output/namcap.log
       - store_artifacts:
           path: output/
+          destination: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: aperezdc/ci-wpebackend:latest
+        user: build
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: aperezdc/ci-wpebackend:latest
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: |
+            rm -rf _build
+            mkdir _build
+            cd _build
+            cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib ..
+            ninja
+      - run:
+          name: Install
+          command: |
+            ninja -C _build install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,24 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Prepare
+          command: |
+            rm -rf _p
+            mkdir -p _p/src/_build
+            curl -sLo _p/PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=wpebackend-git'
+            ln -sf "$(pwd)" _p/src/wpebackend-git
+            cd _p
+      - run:
           name: Build
           command: |
-            rm -rf _build
-            mkdir _build
-            cd _build
-            cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib ..
-            ninja
+            cd _p
+            makepkg --skipinteg --nosign --noextract --force --nocolor
       - run:
-          name: Install
+          name: Check
           command: |
-            ninja -C _build install
+            cd _p
+            while read -r pkg ; do
+              echo "=== ${pkg} ==="
+              namcap "${pkg}"
+              echo ''
+            done < <(makepkg --packagelist) | tee namcap.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
           command: |
             rm -rf _p
             mkdir -p _p/src/_build
-            curl -sLo _p/PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=wpebackend-git'
-            ln -sf "$(pwd)" _p/src/wpebackend-git
+            curl -sLo _p/PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=libwpe-git'
+            ln -sf "$(pwd)" _p/src/libwpe-git
             cd _p
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
       - run:
           name: Prepare
           command: |
-            rm -rf _p
-            mkdir -p _p/src/_build
+            rm -rf _p output
+            mkdir -p _p/src/_build output
             curl -sLo _p/PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=libwpe-git'
             ln -sf "$(pwd)" _p/src/libwpe-git
             cd _p
@@ -24,7 +24,9 @@ jobs:
           command: |
             cd _p
             while read -r pkg ; do
-              echo "=== ${pkg} ==="
+              echo "=== $(basename "${pkg}") ==="
               namcap "${pkg}"
-              echo ''
-            done < <(makepkg --packagelist) | tee namcap.log
+              ln "${pkg}" ../output/
+            done < <(makepkg --packagelist) | tee ../output/namcap.log
+      - store_artifacts:
+          path: output/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,17 @@ jobs:
       - run:
           name: Build
           command: |
-            rm -rf _p output
-            mkdir -p _p/src/_build output
+            rm -rf _p packages
+            mkdir -p _p/src/_build packages
             curl -sLo _p/PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=libwpe-git'
             ln -sf "$(pwd)" _p/src/libwpe-git
             cd _p
             makepkg --skipinteg --nosign --noextract --force --nocolor
             while read -r pkg ; do
-              printf '\n=== %s ===\n\n' "$(basename "${pkg}")"
+              printf '======= %s ======\n' "$(basename "${pkg}")"
               namcap "${pkg}"
-              ln "${pkg}" ../output/
-            done < <(makepkg --packagelist) | tee ../output/namcap.log
+              ln "${pkg}" ../packages/
+            done < <(makepkg --packagelist) | tee ../packages/namcap.log
       - store_artifacts:
-          path: output/
-          destination: ""
+          path: packages/
+          destination: output


### PR DESCRIPTION
This uses a custom Docker image ([aperezdc/ci-wpebackend](https://hub.docker.com/r/aperezdc/ci-wpebackend/)) which has been pre-prepared to include the dependencies needed by WPEBackend.

---

This uses [Circle CI](https://circleci.com) which is free for Open Source projects, and supports using custom Docker images for CI. You can check a successful build [here](https://circleci.com/gh/aperezdc/WPEBackend/7). After merging this it would be needed to enable Circle CI for the `WebPlatformForEmbedded/WPEBackend` repository, and the CI will run for pushes to `master` and also for pull requests.

The `aperezdc/ci-wpebackend` image is created using the tools from my [wpe-ci-images](https://github.com/aperezdc/wpe-ci-images) repository. While I could have used any of the existing base images for GNU/Linux distributions, I wanted to have a way of making my own to further automate things later on: I would like to also have custom base images for [WPEBackend-fdo](https://github.com/Igalia/WPEBackend-fdo) and [Cog](https://github.com/Igalia/cog). In particular the one for Cog will need to have a  build of WPE WebKit preinstalled, otherwise CI runs would be painfully slow.

Also, I wanted to figure out a way of making Docker images without needing Docker running, which will make it easier e.g. to use the CI to produce an image which includes the results from building WPEBackend, WPEBackend-fdo, and WPE WebKit as a build artifact, and *then* directly use that for Cog's CI.

As you can see, there are still many moving parts to figure out to have a complete story for all the repositories involved, but I think this is a good first step—we have to start somewhere after all!