### PR TITLE
Mark client struct parameters as const in _create() functions

### DIFF
--- a/include/wpe/renderer-backend-egl.h
+++ b/include/wpe/renderer-backend-egl.h
@@ -101,7 +101,7 @@ void
 wpe_renderer_backend_egl_target_destroy(struct wpe_renderer_backend_egl_target*);
 
 void
-wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_target*, struct wpe_renderer_backend_egl_target_client*, void*);
+wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_target*, const struct wpe_renderer_backend_egl_target_client*, void*);
 
 void
 wpe_renderer_backend_egl_target_initialize(struct wpe_renderer_backend_egl_target*, struct wpe_renderer_backend_egl*, uint32_t, uint32_t);

--- a/include/wpe/view-backend.h
+++ b/include/wpe/view-backend.h
@@ -71,10 +71,10 @@ void
 wpe_view_backend_destroy(struct wpe_view_backend*);
 
 void 
-wpe_view_backend_set_backend_client(struct wpe_view_backend*, struct wpe_view_backend_client*, void*);
+wpe_view_backend_set_backend_client(struct wpe_view_backend*, const struct wpe_view_backend_client*, void*);
 
 void
-wpe_view_backend_set_input_client(struct wpe_view_backend*, struct wpe_view_backend_input_client*, void*);
+wpe_view_backend_set_input_client(struct wpe_view_backend*, const struct wpe_view_backend_input_client*, void*);
 
 void
 wpe_view_backend_initialize(struct wpe_view_backend*);

--- a/src/renderer-backend-egl-private.h
+++ b/src/renderer-backend-egl-private.h
@@ -36,7 +36,7 @@ struct wpe_renderer_backend_egl_target {
     const struct wpe_renderer_backend_egl_target_interface* interface;
     void* interface_data;
 
-    struct wpe_renderer_backend_egl_target_client* client;
+    const struct wpe_renderer_backend_egl_target_client* client;
     void* client_data;
 };
 

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -90,7 +90,7 @@ wpe_renderer_backend_egl_target_destroy(struct wpe_renderer_backend_egl_target* 
 
 __attribute__((visibility("default")))
 void
-wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_target* target, struct wpe_renderer_backend_egl_target_client* client, void* client_data)
+wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_target* target, const struct wpe_renderer_backend_egl_target_client* client, void* client_data)
 {
     target->client = client;
     target->client_data = client_data;

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -37,10 +37,10 @@ struct wpe_view_backend {
     const struct wpe_view_backend_interface* interface;
     void* interface_data;
 
-    struct wpe_view_backend_client* backend_client;
+    const struct wpe_view_backend_client* backend_client;
     void* backend_client_data;
 
-    struct wpe_view_backend_input_client* input_client;
+    const struct wpe_view_backend_input_client* input_client;
     void* input_client_data;
 };
 

--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -74,7 +74,7 @@ wpe_view_backend_destroy(struct wpe_view_backend* backend)
 
 __attribute__((visibility("default")))
 void
-wpe_view_backend_set_backend_client(struct wpe_view_backend* backend, struct wpe_view_backend_client* client, void* client_data)
+wpe_view_backend_set_backend_client(struct wpe_view_backend* backend, const struct wpe_view_backend_client* client, void* client_data)
 {
     backend->backend_client = client;
     backend->backend_client_data = client_data;
@@ -82,7 +82,7 @@ wpe_view_backend_set_backend_client(struct wpe_view_backend* backend, struct wpe
 
 __attribute__((visibility("default")))
 void
-wpe_view_backend_set_input_client(struct wpe_view_backend* backend, struct wpe_view_backend_input_client* client, void* client_data)
+wpe_view_backend_set_input_client(struct wpe_view_backend* backend, const struct wpe_view_backend_input_client* client, void* client_data)
 {
     backend->input_client = client;
     backend->input_client_data = client_data;


### PR DESCRIPTION
The client structs are used vtables, which in shouldn't change, so the parameters to the client setter functions can be marked `const`.

----

This is in the same vein as https://github.com/Igalia/WPEBackend-fdo/pull/24