### PR TITLE
renderer-backend-egl.c: check interface pointer before usage

### DIFF
--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -39,6 +39,9 @@ wpe_renderer_backend_egl_create(int host_fd)
         return 0;
 
     backend->interface = wpe_load_object("_wpe_renderer_backend_egl_interface");
+    if (!backend->interface)
+        return 0;
+
     backend->interface_data = backend->interface->create(host_fd);
 
     return backend;
@@ -70,6 +73,9 @@ wpe_renderer_backend_egl_target_create(int host_fd)
         return 0;
 
     target->interface = wpe_load_object("_wpe_renderer_backend_egl_target_interface");
+    if (!target->interface)
+        return 0;
+
     target->interface_data = target->interface->create(target, host_fd);
 
     return target;
@@ -140,6 +146,9 @@ wpe_renderer_backend_egl_offscreen_target_create()
         return 0;
 
     target->interface = wpe_load_object("_wpe_renderer_backend_egl_offscreen_target_interface");
+    if (!target->interface)
+        return 0;
+
     target->interface_data = target->interface->create();
 
     return target;


### PR DESCRIPTION
The interface is used without checking for a valid address. In some
cases it may lead to NULL dereference and segmentation fault.
This was the case with the wpebackend-fdo which was returning nullptr
when requesting for the _wpe_renderer_backend_egl_offscreen_target_interface.

https://github.com/Igalia/meta-webkit/issues/31#issuecomment-427983230

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>