### PR TITLE
Add export macro to support __declspec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set(WPE_SOURCES
 
 set(WPE_PUBLIC_HEADERS
   ${DERIVED_SOURCES_DIR}/version.h
+  include/wpe/export.h
   include/wpe/input.h
   include/wpe/keysyms.h
   include/wpe/loader.h

--- a/include/wpe/export.h
+++ b/include/wpe/export.h
@@ -24,22 +24,34 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "version.h"
+#if !defined(__WPE_H_INSIDE__) && !defined(WPE_COMPILATION)
+#error "Only <wpe/wpe.h> can be included directly."
+#endif
 
-unsigned
-wpe_backend_get_major_version(void)
-{
-    return WPE_BACKEND_MAJOR_VERSION;
-}
+#ifndef wpe_export_h
+#define wpe_export_h
 
-unsigned
-wpe_backend_get_minor_version(void)
-{
-    return WPE_BACKEND_MINOR_VERSION;
-}
+#if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
+#define WIN32
+#endif
 
-unsigned
-wpe_backend_get_micro_version(void)
-{
-    return WPE_BACKEND_MICRO_VERSION;
-}
+/* Compatibility for non-Clang compilers */
+#ifndef __has_declspec_attribute
+#define __has_declspec_attribute(x) 0
+#endif
+
+#if defined(WIN32) || (__has_declspec_attribute(dllexport) && __has_declspec_attribute(dllimport))
+#ifdef WPE_COMPILATION
+#define WPE_EXPORT __declspec(dllexport)  
+#else
+#define WPE_EXPORT __declspec(dllimport)
+#endif
+#else
+#ifdef WPE_COMPILATION
+#define WPE_EXPORT __attribute__((visibility("default")))
+#else
+#define WPE_EXPORT
+#endif
+#endif
+
+#endif /* wpe_export_h */

--- a/include/wpe/input.h
+++ b/include/wpe/input.h
@@ -31,6 +31,10 @@
 #ifndef wpe_input_h
 #define wpe_input_h
 
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <xkbcommon/xkbcommon.h>
@@ -128,42 +132,55 @@ struct wpe_input_xkb_keymap_entry {
     int32_t level;
 };
 
+WPE_EXPORT
 struct wpe_input_xkb_context*
 wpe_input_xkb_context_get_default();
 
+WPE_EXPORT
 struct xkb_context*
 wpe_input_xkb_context_get_context(struct wpe_input_xkb_context*);
 
+WPE_EXPORT
 struct xkb_keymap*
 wpe_input_xkb_context_get_keymap(struct wpe_input_xkb_context*);
 
+WPE_EXPORT
 void
 wpe_input_xkb_context_set_keymap(struct wpe_input_xkb_context*, struct xkb_keymap*);
 
+WPE_EXPORT
 struct xkb_state*
 wpe_input_xkb_context_get_state(struct wpe_input_xkb_context*);
 
+WPE_EXPORT
 struct xkb_compose_table*
 wpe_input_xkb_context_get_compose_table(struct wpe_input_xkb_context*);
 
+WPE_EXPORT
 void
 wpe_input_xkb_context_set_compose_table(struct wpe_input_xkb_context*, struct xkb_compose_table*);
 
+WPE_EXPORT
 struct xkb_compose_state*
 wpe_input_xkb_context_get_compose_state(struct wpe_input_xkb_context*);
 
+WPE_EXPORT
 uint32_t
 wpe_input_xkb_context_get_modifiers(struct wpe_input_xkb_context*, uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group);
 
+WPE_EXPORT
 uint32_t
 wpe_input_xkb_context_get_key_code(struct wpe_input_xkb_context*, uint32_t hardware_key_code, bool pressed);
 
+WPE_EXPORT
 void
 wpe_input_xkb_context_get_entries_for_key_code(struct wpe_input_xkb_context*, uint32_t key_code, struct wpe_input_xkb_keymap_entry**, uint32_t* n_entries);
 
+WPE_EXPORT
 uint32_t
 wpe_key_code_to_unicode (uint32_t);
 
+WPE_EXPORT
 uint32_t
 wpe_unicode_to_key_code (uint32_t);
 

--- a/include/wpe/loader.h
+++ b/include/wpe/loader.h
@@ -31,6 +31,10 @@
 #ifndef wpe_loader_h
 #define wpe_loader_h
 
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
+
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -45,9 +49,11 @@ struct wpe_loader_interface {
     void (*_wpe_reserved3)(void);
 };
 
+WPE_EXPORT
 bool
 wpe_loader_init(const char* impl_library_name);
 
+WPE_EXPORT
 const char*
 wpe_loader_get_loaded_implementation_library_name(void);
 

--- a/include/wpe/pasteboard.h
+++ b/include/wpe/pasteboard.h
@@ -31,6 +31,10 @@
 #ifndef wpe_pasteboard_h
 #define wpe_pasteboard_h
 
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -57,12 +61,15 @@ struct wpe_pasteboard_string_map {
     uint64_t length;
 };
 
+WPE_EXPORT
 void
 wpe_pasteboard_string_initialize(struct wpe_pasteboard_string*, const char*, uint64_t);
 
+WPE_EXPORT
 void
 wpe_pasteboard_string_free(struct wpe_pasteboard_string*);
 
+WPE_EXPORT
 void
 wpe_pasteboard_string_vector_free(struct wpe_pasteboard_string_vector*);
 
@@ -82,15 +89,19 @@ struct wpe_pasteboard_interface {
     void (*_wpe_reserved3)(void);
 };
 
+WPE_EXPORT
 struct wpe_pasteboard*
 wpe_pasteboard_get_singleton();
 
+WPE_EXPORT
 void
 wpe_pasteboard_get_types(struct wpe_pasteboard*, struct wpe_pasteboard_string_vector*);
 
+WPE_EXPORT
 void
 wpe_pasteboard_get_string(struct wpe_pasteboard*, const char*, struct wpe_pasteboard_string*);
 
+WPE_EXPORT
 void
 wpe_pasteboard_write(struct wpe_pasteboard*, struct wpe_pasteboard_string_map*);
 

--- a/include/wpe/renderer-backend-egl.h
+++ b/include/wpe/renderer-backend-egl.h
@@ -31,6 +31,10 @@
 #ifndef wpe_renderer_backend_egl_h
 #define wpe_renderer_backend_egl_h
 
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
+
 #include <EGL/eglplatform.h>
 #include <stdint.h>
 
@@ -85,48 +89,63 @@ struct wpe_renderer_backend_egl_offscreen_target_interface {
     void (*_wpe_reserved3)(void);
 };
 
+WPE_EXPORT
 struct wpe_renderer_backend_egl*
 wpe_renderer_backend_egl_create(int);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_destroy(struct wpe_renderer_backend_egl*);
 
+WPE_EXPORT
 EGLNativeDisplayType
 wpe_renderer_backend_egl_get_native_display(struct wpe_renderer_backend_egl*);
 
+WPE_EXPORT
 struct wpe_renderer_backend_egl_target*
 wpe_renderer_backend_egl_target_create(int);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_destroy(struct wpe_renderer_backend_egl_target*);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_target*, struct wpe_renderer_backend_egl_target_client*, void*);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_initialize(struct wpe_renderer_backend_egl_target*, struct wpe_renderer_backend_egl*, uint32_t, uint32_t);
 
+WPE_EXPORT
 EGLNativeWindowType
 wpe_renderer_backend_egl_target_get_native_window(struct wpe_renderer_backend_egl_target*);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_resize(struct wpe_renderer_backend_egl_target*, uint32_t, uint32_t);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_frame_will_render(struct wpe_renderer_backend_egl_target*);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_frame_rendered(struct wpe_renderer_backend_egl_target*);
 
+WPE_EXPORT
 struct wpe_renderer_backend_egl_offscreen_target*
 wpe_renderer_backend_egl_offscreen_target_create();
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_offscreen_target_destroy(struct wpe_renderer_backend_egl_offscreen_target*);
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_offscreen_target_initialize(struct wpe_renderer_backend_egl_offscreen_target*, struct wpe_renderer_backend_egl*);
 
+WPE_EXPORT
 EGLNativeWindowType
 wpe_renderer_backend_egl_offscreen_target_get_native_window(struct wpe_renderer_backend_egl_offscreen_target*);
 
@@ -138,6 +157,7 @@ struct wpe_renderer_backend_egl_target_client {
     void (*_wpe_reserved3)(void);
 };
 
+WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_dispatch_frame_complete(struct wpe_renderer_backend_egl_target*);
 

--- a/include/wpe/renderer-host.h
+++ b/include/wpe/renderer-host.h
@@ -31,6 +31,10 @@
 #ifndef wpe_renderer_host_h
 #define wpe_renderer_host_h
 
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,6 +51,7 @@ struct wpe_renderer_host_interface {
     void (*_wpe_reserved3)(void);
 };
 
+WPE_EXPORT
 int
 wpe_renderer_host_create_client();
 

--- a/include/wpe/version.h.cmake
+++ b/include/wpe/version.h.cmake
@@ -31,6 +31,10 @@
 #ifndef wpe_version_h
 #define wpe_version_h
 
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -45,11 +49,11 @@ extern "C" {
     (WPE_BACKEND_MAJOR_VERSION == (major) && WPE_BACKEND_MINOR_VERSION == (minor) && \
      WPE_BACKEND_MICRO_VERSION >= (micro)))
 
-unsigned wpe_backend_get_major_version(void);
+WPE_EXPORT unsigned wpe_backend_get_major_version(void);
 
-unsigned wpe_backend_get_minor_version(void);
+WPE_EXPORT unsigned wpe_backend_get_minor_version(void);
 
-unsigned wpe_backend_get_micro_version(void);
+WPE_EXPORT unsigned wpe_backend_get_micro_version(void);
 
 #ifdef __cplusplus
 }

--- a/include/wpe/view-backend.h
+++ b/include/wpe/view-backend.h
@@ -31,6 +31,10 @@
 #ifndef wpe_view_backend_h
 #define wpe_view_backend_h
 
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -61,24 +65,31 @@ struct wpe_view_backend_interface {
 };
 
 
+WPE_EXPORT
 struct wpe_view_backend*
 wpe_view_backend_create();
 
+WPE_EXPORT
 struct wpe_view_backend*
 wpe_view_backend_create_with_backend_interface(struct wpe_view_backend_interface*, void*);
 
+WPE_EXPORT
 void
 wpe_view_backend_destroy(struct wpe_view_backend*);
 
+WPE_EXPORT
 void 
 wpe_view_backend_set_backend_client(struct wpe_view_backend*, struct wpe_view_backend_client*, void*);
 
+WPE_EXPORT
 void
 wpe_view_backend_set_input_client(struct wpe_view_backend*, struct wpe_view_backend_input_client*, void*);
 
+WPE_EXPORT
 void
 wpe_view_backend_initialize(struct wpe_view_backend*);
 
+WPE_EXPORT
 int
 wpe_view_backend_get_renderer_host_fd(struct wpe_view_backend*);
 
@@ -92,9 +103,11 @@ struct wpe_view_backend_client {
     void (*_wpe_reserved3)(void);
 };
 
+WPE_EXPORT
 void
 wpe_view_backend_dispatch_set_size(struct wpe_view_backend*, uint32_t, uint32_t);
 
+WPE_EXPORT
 void
 wpe_view_backend_dispatch_frame_displayed(struct wpe_view_backend*);
 
@@ -110,15 +123,19 @@ struct wpe_view_backend_input_client {
     void (*_wpe_reserved3)(void);
 };
 
+WPE_EXPORT
 void
 wpe_view_backend_dispatch_keyboard_event(struct wpe_view_backend*, struct wpe_input_keyboard_event*);
 
+WPE_EXPORT
 void
 wpe_view_backend_dispatch_pointer_event(struct wpe_view_backend*, struct wpe_input_pointer_event*);
 
+WPE_EXPORT
 void
 wpe_view_backend_dispatch_axis_event(struct wpe_view_backend*, struct wpe_input_axis_event*);
 
+WPE_EXPORT
 void
 wpe_view_backend_dispatch_touch_event(struct wpe_view_backend*, struct wpe_input_touch_event*);
 

--- a/include/wpe/wpe.h
+++ b/include/wpe/wpe.h
@@ -34,6 +34,7 @@
 
 #define __WPE_H_INSIDE__
 
+#include <wpe/export.h>
 #include <wpe/input.h>
 #include <wpe/keysyms.h>
 #include <wpe/loader.h>

--- a/src/input.c
+++ b/src/input.c
@@ -37,7 +37,6 @@ struct wpe_input_xkb_context {
     struct xkb_compose_state* compose_state;
 };
 
-__attribute__((visibility("default")))
 struct wpe_input_xkb_context*
 wpe_input_xkb_context_get_default()
 {
@@ -50,7 +49,6 @@ wpe_input_xkb_context_get_default()
     return s_xkb_context;
 }
 
-__attribute__((visibility("default")))
 struct xkb_context*
 wpe_input_xkb_context_get_context(struct wpe_input_xkb_context* xkb_context)
 {
@@ -71,7 +69,6 @@ wpe_input_xkb_context_try_ensure_keymap(struct wpe_input_xkb_context* xkb_contex
     }
 }
 
-__attribute__((visibility("default")))
 struct xkb_keymap*
 wpe_input_xkb_context_get_keymap(struct wpe_input_xkb_context* xkb_context)
 {
@@ -80,7 +77,6 @@ wpe_input_xkb_context_get_keymap(struct wpe_input_xkb_context* xkb_context)
     return state ? xkb_state_get_keymap(state) : NULL;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_input_xkb_context_set_keymap(struct wpe_input_xkb_context* xkb_context, struct xkb_keymap* keymap)
 {
@@ -92,7 +88,6 @@ wpe_input_xkb_context_set_keymap(struct wpe_input_xkb_context* xkb_context, stru
     xkb_context->state = xkb_state_new(keymap);
 }
 
-__attribute__((visibility("default")))
 struct xkb_state*
 wpe_input_xkb_context_get_state(struct wpe_input_xkb_context* xkb_context)
 {
@@ -114,7 +109,6 @@ wpe_input_xkb_context_try_ensure_compose_table(struct wpe_input_xkb_context* xkb
     }
 }
 
-__attribute__((visibility("default")))
 struct xkb_compose_table*
 wpe_input_xkb_context_get_compose_table(struct wpe_input_xkb_context* xkb_context)
 {
@@ -123,7 +117,6 @@ wpe_input_xkb_context_get_compose_table(struct wpe_input_xkb_context* xkb_contex
     return state ? xkb_compose_state_get_compose_table(state) : NULL;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_input_xkb_context_set_compose_table(struct wpe_input_xkb_context* xkb_context, struct xkb_compose_table* compose_table)
 {
@@ -135,7 +128,6 @@ wpe_input_xkb_context_set_compose_table(struct wpe_input_xkb_context* xkb_contex
     xkb_context->compose_state = xkb_compose_state_new(compose_table, XKB_COMPOSE_STATE_NO_FLAGS);
 }
 
-__attribute__((visibility("default")))
 struct xkb_compose_state*
 wpe_input_xkb_context_get_compose_state(struct wpe_input_xkb_context* xkb_context)
 {
@@ -144,7 +136,6 @@ wpe_input_xkb_context_get_compose_state(struct wpe_input_xkb_context* xkb_contex
     return xkb_context->compose_state;
 }
 
-__attribute__((visibility("default")))
 uint32_t
 wpe_input_xkb_context_get_modifiers(struct wpe_input_xkb_context* xkb_context, uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group)
 {
@@ -168,7 +159,6 @@ wpe_input_xkb_context_get_modifiers(struct wpe_input_xkb_context* xkb_context, u
     return retval;
 }
 
-__attribute__((visibility("default")))
 uint32_t
 wpe_input_xkb_context_get_key_code(struct wpe_input_xkb_context* xkb_context, uint32_t hardware_key_code, bool pressed)
 {
@@ -201,7 +191,6 @@ wpe_input_xkb_context_get_key_code(struct wpe_input_xkb_context* xkb_context, ui
     return sym;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_input_xkb_context_get_entries_for_key_code(struct wpe_input_xkb_context* xkb_context, uint32_t key, struct wpe_input_xkb_keymap_entry** entries, uint32_t* n_entries)
 {

--- a/src/key-unicode.c
+++ b/src/key-unicode.c
@@ -17,7 +17,7 @@
 
 /* This file is based on gdkkeyuni.c adapted to WPE */
 
-#include <stdint.h>
+#include <wpe/input.h>
 #include <wpe/keysyms.h>
 
 /* Thanks to Markus G. Kuhn <mkuhn@acm.org> for the ksysym<->Unicode
@@ -856,7 +856,6 @@ static const struct {
     { 0xFFFF /* Delete */, '\177' }
 };
 
-__attribute__((visibility("default")))
 uint32_t
 wpe_key_code_to_unicode (uint32_t key_code)
 {
@@ -1643,7 +1642,6 @@ static const struct {
     { 0x0ef7, 0x318e }, /*               Hangul_AraeAE ㆎ HANGUL LETTER ARAEAE */
 };
 
-__attribute__((visibility("default")))
 uint32_t
 wpe_unicode_to_key_code (uint32_t wc)
 {

--- a/src/loader.c
+++ b/src/loader.c
@@ -97,7 +97,6 @@ load_impl_library()
     s_impl_loader = dlsym(s_impl_library, "_wpe_loader_interface");
 }
 
-__attribute__((visibility("default")))
 bool
 wpe_loader_init(const char* impl_library_name)
 {
@@ -129,7 +128,6 @@ wpe_loader_init(const char* impl_library_name)
 #endif
 }
 
-__attribute__((visibility("default")))
 const char*
 wpe_loader_get_loaded_implementation_library_name(void)
 {

--- a/src/pasteboard.c
+++ b/src/pasteboard.c
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-__attribute__((visibility("default")))
 void
 wpe_pasteboard_string_initialize(struct wpe_pasteboard_string* string, const char* in_string, uint64_t in_length)
 {
@@ -42,7 +41,6 @@ wpe_pasteboard_string_initialize(struct wpe_pasteboard_string* string, const cha
     memcpy(string->data, in_string, in_length);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_pasteboard_string_free(struct wpe_pasteboard_string* string)
 {
@@ -52,7 +50,6 @@ wpe_pasteboard_string_free(struct wpe_pasteboard_string* string)
     string->length = 0;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_pasteboard_string_vector_free(struct wpe_pasteboard_string_vector* vector)
 {
@@ -65,7 +62,6 @@ wpe_pasteboard_string_vector_free(struct wpe_pasteboard_string_vector* vector)
     vector->length = 0;
 }
 
-__attribute__((visibility("default")))
 struct wpe_pasteboard*
 wpe_pasteboard_get_singleton()
 {
@@ -81,21 +77,18 @@ wpe_pasteboard_get_singleton()
     return s_pasteboard;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_pasteboard_get_types(struct wpe_pasteboard* pasteboard, struct wpe_pasteboard_string_vector* out_types)
 {
     pasteboard->interface->get_types(pasteboard->interface_data, out_types);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_pasteboard_get_string(struct wpe_pasteboard* pasteboard, const char* type, struct wpe_pasteboard_string* out_string)
 {
     pasteboard->interface->get_string(pasteboard->interface_data, type, out_string);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_pasteboard_write(struct wpe_pasteboard* pasteboard, struct wpe_pasteboard_string_map* map)
 {

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -30,7 +30,6 @@
 #include "renderer-backend-egl-private.h"
 #include <stdlib.h>
 
-__attribute__((visibility("default")))
 struct wpe_renderer_backend_egl*
 wpe_renderer_backend_egl_create(int host_fd)
 {
@@ -44,7 +43,6 @@ wpe_renderer_backend_egl_create(int host_fd)
     return backend;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_destroy(struct wpe_renderer_backend_egl* backend)
 {
@@ -54,14 +52,12 @@ wpe_renderer_backend_egl_destroy(struct wpe_renderer_backend_egl* backend)
     free(backend);
 }
 
-__attribute__((visibility("default")))
 EGLNativeDisplayType
 wpe_renderer_backend_egl_get_native_display(struct wpe_renderer_backend_egl* backend)
 {
     return backend->interface->get_native_display(backend->interface_data);
 }
 
-__attribute__((visibility("default")))
 struct wpe_renderer_backend_egl_target*
 wpe_renderer_backend_egl_target_create(int host_fd)
 {
@@ -75,7 +71,6 @@ wpe_renderer_backend_egl_target_create(int host_fd)
     return target;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_target_destroy(struct wpe_renderer_backend_egl_target* target)
 {
@@ -88,7 +83,6 @@ wpe_renderer_backend_egl_target_destroy(struct wpe_renderer_backend_egl_target* 
     free(target);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_target* target, struct wpe_renderer_backend_egl_target_client* client, void* client_data)
 {
@@ -96,42 +90,36 @@ wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_targe
     target->client_data = client_data;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_target_initialize(struct wpe_renderer_backend_egl_target* target, struct wpe_renderer_backend_egl* backend, uint32_t width, uint32_t height)
 {
     target->interface->initialize(target->interface_data, backend->interface_data, width, height);
 }
 
-__attribute__((visibility("default")))
 EGLNativeWindowType
 wpe_renderer_backend_egl_target_get_native_window(struct wpe_renderer_backend_egl_target* target)
 {
     return target->interface->get_native_window(target->interface_data);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_target_resize(struct wpe_renderer_backend_egl_target* target, uint32_t width, uint32_t height)
 {
     target->interface->resize(target->interface_data, width, height);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_target_frame_will_render(struct wpe_renderer_backend_egl_target* target)
 {
     target->interface->frame_will_render(target->interface_data);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_target_frame_rendered(struct wpe_renderer_backend_egl_target* target)
 {
     target->interface->frame_rendered(target->interface_data);
 }
 
-__attribute__((visibility("default")))
 struct wpe_renderer_backend_egl_offscreen_target*
 wpe_renderer_backend_egl_offscreen_target_create()
 {
@@ -145,7 +133,6 @@ wpe_renderer_backend_egl_offscreen_target_create()
     return target;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_offscreen_target_destroy(struct wpe_renderer_backend_egl_offscreen_target* target)
 {
@@ -155,21 +142,18 @@ wpe_renderer_backend_egl_offscreen_target_destroy(struct wpe_renderer_backend_eg
     free(target);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_offscreen_target_initialize(struct wpe_renderer_backend_egl_offscreen_target* target, struct wpe_renderer_backend_egl* backend)
 {
     target->interface->initialize(target->interface_data, backend->interface_data);
 }
 
-__attribute__((visibility("default")))
 EGLNativeWindowType
 wpe_renderer_backend_egl_offscreen_target_get_native_window(struct wpe_renderer_backend_egl_offscreen_target* target)
 {
     return target->interface->get_native_window(target->interface_data);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_renderer_backend_egl_target_dispatch_frame_complete(struct wpe_renderer_backend_egl_target* target)
 {

--- a/src/renderer-host.c
+++ b/src/renderer-host.c
@@ -30,7 +30,6 @@
 #include "renderer-host-private.h"
 #include <stdlib.h>
 
-__attribute__((visibility("default")))
 int
 wpe_renderer_host_create_client()
 {

--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 
 
-__attribute__((visibility("default")))
 struct wpe_view_backend*
 wpe_view_backend_create()
 {
@@ -42,7 +41,6 @@ wpe_view_backend_create()
     return wpe_view_backend_create_with_backend_interface(backend_interface, 0);
 }
 
-__attribute__((visibility("default")))
 struct wpe_view_backend*
 wpe_view_backend_create_with_backend_interface(struct wpe_view_backend_interface* interface, void* interface_user_data)
 {
@@ -56,7 +54,6 @@ wpe_view_backend_create_with_backend_interface(struct wpe_view_backend_interface
     return backend;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_destroy(struct wpe_view_backend* backend)
 {
@@ -72,7 +69,6 @@ wpe_view_backend_destroy(struct wpe_view_backend* backend)
     free(backend);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_set_backend_client(struct wpe_view_backend* backend, struct wpe_view_backend_client* client, void* client_data)
 {
@@ -80,7 +76,6 @@ wpe_view_backend_set_backend_client(struct wpe_view_backend* backend, struct wpe
     backend->backend_client_data = client_data;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_set_input_client(struct wpe_view_backend* backend, struct wpe_view_backend_input_client* client, void* client_data)
 {
@@ -88,21 +83,18 @@ wpe_view_backend_set_input_client(struct wpe_view_backend* backend, struct wpe_v
     backend->input_client_data = client_data;
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_initialize(struct wpe_view_backend* backend)
 {
     backend->interface->initialize(backend->interface_data);
 }
 
-__attribute__((visibility("default")))
 int
 wpe_view_backend_get_renderer_host_fd(struct wpe_view_backend* backend)
 {
     return backend->interface->get_renderer_host_fd(backend->interface_data);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_dispatch_set_size(struct wpe_view_backend* backend, uint32_t width, uint32_t height)
 {
@@ -110,7 +102,6 @@ wpe_view_backend_dispatch_set_size(struct wpe_view_backend* backend, uint32_t wi
         backend->backend_client->set_size(backend->backend_client_data, width, height);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_dispatch_frame_displayed(struct wpe_view_backend* backend)
 {
@@ -118,7 +109,6 @@ wpe_view_backend_dispatch_frame_displayed(struct wpe_view_backend* backend)
         backend->backend_client->frame_displayed(backend->backend_client_data);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_dispatch_keyboard_event(struct wpe_view_backend* backend, struct wpe_input_keyboard_event* event)
 {
@@ -126,7 +116,6 @@ wpe_view_backend_dispatch_keyboard_event(struct wpe_view_backend* backend, struc
         backend->input_client->handle_keyboard_event(backend->input_client_data, event);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_dispatch_pointer_event(struct wpe_view_backend* backend, struct wpe_input_pointer_event* event)
 {
@@ -134,7 +123,6 @@ wpe_view_backend_dispatch_pointer_event(struct wpe_view_backend* backend, struct
         backend->input_client->handle_pointer_event(backend->input_client_data, event);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_dispatch_axis_event(struct wpe_view_backend* backend, struct wpe_input_axis_event* event)
 {
@@ -142,7 +130,6 @@ wpe_view_backend_dispatch_axis_event(struct wpe_view_backend* backend, struct wp
         backend->input_client->handle_axis_event(backend->input_client_data, event);
 }
 
-__attribute__((visibility("default")))
 void
 wpe_view_backend_dispatch_touch_event(struct wpe_view_backend* backend, struct wpe_input_touch_event* event)
 {


### PR DESCRIPTION
This replaces instances of `__attribute__((visibility("default")))` with `WPE_EXPORT` in order to support platforms with `__declspec` such as Windows.