### PR TITLE
Including wpe-egl.h should include also wpe.h

### DIFF
--- a/include/wpe/wpe-egl.h
+++ b/include/wpe/wpe-egl.h
@@ -34,6 +34,7 @@
 
 #define __WPE_EGL_H_INSIDE__
 
+#include <wpe/wpe.h>
 #include <wpe/renderer-backend-egl.h>
 
 #undef __WPE_EGL_H_INSIDE__


### PR DESCRIPTION
This is needed to ensure that all the other needed definitions are included. One should not need to have to include both manually, even less knowing that `wpe.h` has to be included before `wpe-egl.h`.

This is particularly important now that we have the definition for `WPE_EXPORT` and `wpe.h` takes care of including the header necessary to bring its definition into scope.