### PR TITLE
Rename version API to stop using the word backend

### DIFF
--- a/include/wpe/version-deprecated.h.cmake
+++ b/include/wpe/version-deprecated.h.cmake
@@ -24,41 +24,39 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "version.h"
-#include "version-deprecated.h"
+#if !defined(__WPE_H_INSIDE__) && !defined(WPE_COMPILATION)
+#error "Only <wpe/wpe.h> can be included directly."
+#endif
 
-unsigned
-wpe_get_major_version(void)
-{
-    return WPE_BACKEND_MAJOR_VERSION;
-}
+#ifndef wpe_version_deprecated_h
+#define wpe_version_deprecated_h
 
-unsigned
-wpe_get_minor_version(void)
-{
-    return WPE_BACKEND_MINOR_VERSION;
-}
+#if defined(WPE_COMPILATION)
+#include <wpe/export.h>
+#endif
 
-unsigned
-wpe_get_micro_version(void)
-{
-    return WPE_BACKEND_MICRO_VERSION;
-}
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-unsigned
-wpe_backend_get_major_version(void)
-{
-    return wpe_get_major_version();
-}
+#define WPE_BACKEND_MAJOR_VERSION (@PROJECT_VERSION_MAJOR@)
+#define WPE_BACKEND_MINOR_VERSION (@PROJECT_VERSION_MINOR@)
+#define WPE_BACKEND_MICRO_VERSION (@PROJECT_VERSION_PATCH@)
 
-unsigned
-wpe_backend_get_minor_version(void)
-{
-    return wpe_get_minor_version();
-}
+#define WPE_BACKEND_CHECK_VERSION(major, minor, micro) \
+    (WPE_BACKEND_MAJOR_VERSION > (major) || \
+    (WPE_BACKEND_MAJOR_VERSION == (major) && WPE_BACKEND_MINOR_VERSION > (minor)) || \
+    (WPE_BACKEND_MAJOR_VERSION == (major) && WPE_BACKEND_MINOR_VERSION == (minor) && \
+     WPE_BACKEND_MICRO_VERSION >= (micro)))
 
-unsigned
-wpe_backend_get_micro_version(void)
-{
-    return wpe_get_micro_version();
+WPE_EXPORT unsigned wpe_backend_get_major_version(void);
+
+WPE_EXPORT unsigned wpe_backend_get_minor_version(void);
+
+WPE_EXPORT unsigned wpe_backend_get_micro_version(void);
+
+#ifdef __cplusplus
 }
+#endif
+
+#endif /* wpe_version_deprecated_h */

--- a/include/wpe/version.h.cmake
+++ b/include/wpe/version.h.cmake
@@ -39,21 +39,21 @@
 extern "C" {
 #endif
 
-#define WPE_BACKEND_MAJOR_VERSION (@PROJECT_VERSION_MAJOR@)
-#define WPE_BACKEND_MINOR_VERSION (@PROJECT_VERSION_MINOR@)
-#define WPE_BACKEND_MICRO_VERSION (@PROJECT_VERSION_PATCH@)
+#define WPE_MAJOR_VERSION (@PROJECT_VERSION_MAJOR@)
+#define WPE_MINOR_VERSION (@PROJECT_VERSION_MINOR@)
+#define WPE_MICRO_VERSION (@PROJECT_VERSION_PATCH@)
 
-#define WPE_BACKEND_CHECK_VERSION(major, minor, micro) \
-    (WPE_BACKEND_MAJOR_VERSION > (major) || \
-    (WPE_BACKEND_MAJOR_VERSION == (major) && WPE_BACKEND_MINOR_VERSION > (minor)) || \
-    (WPE_BACKEND_MAJOR_VERSION == (major) && WPE_BACKEND_MINOR_VERSION == (minor) && \
-     WPE_BACKEND_MICRO_VERSION >= (micro)))
+#define WPE_CHECK_VERSION(major, minor, micro) \
+    (WPE_MAJOR_VERSION > (major) || \
+    (WPE_MAJOR_VERSION == (major) && WPE_MINOR_VERSION > (minor)) || \
+    (WPE_MAJOR_VERSION == (major) && WPE_MINOR_VERSION == (minor) && \
+     WPE_MICRO_VERSION >= (micro)))
 
-WPE_EXPORT unsigned wpe_backend_get_major_version(void);
+WPE_EXPORT unsigned wpe_get_major_version(void);
 
-WPE_EXPORT unsigned wpe_backend_get_minor_version(void);
+WPE_EXPORT unsigned wpe_get_minor_version(void);
 
-WPE_EXPORT unsigned wpe_backend_get_micro_version(void);
+WPE_EXPORT unsigned wpe_get_micro_version(void);
 
 #ifdef __cplusplus
 }

--- a/include/wpe/wpe.h
+++ b/include/wpe/wpe.h
@@ -41,6 +41,7 @@
 #include <wpe/pasteboard.h>
 #include <wpe/renderer-host.h>
 #include <wpe/version.h>
+#include <wpe/version-deprecated.h>
 #include <wpe/view-backend.h>
 
 #undef __WPE_H_INSIDE__


### PR DESCRIPTION
The library was renamed, but version API still includes backend word.
Deprecate the old API and add new one using using just WPE.