### PR TITLE
Add an API to get the EGL platform identifier

### DIFF
--- a/include/wpe/renderer-backend-egl.h
+++ b/include/wpe/renderer-backend-egl.h
@@ -53,8 +53,8 @@ struct wpe_renderer_backend_egl_interface {
     void (*destroy)(void*);
 
     EGLNativeDisplayType (*get_native_display)(void*);
+    uint32_t (*get_platform)(void*);
 
-    void (*_wpe_reserved0)(void);
     void (*_wpe_reserved1)(void);
     void (*_wpe_reserved2)(void);
     void (*_wpe_reserved3)(void);
@@ -100,6 +100,10 @@ wpe_renderer_backend_egl_destroy(struct wpe_renderer_backend_egl*);
 WPE_EXPORT
 EGLNativeDisplayType
 wpe_renderer_backend_egl_get_native_display(struct wpe_renderer_backend_egl*);
+
+WPE_EXPORT
+uint32_t
+wpe_renderer_backend_egl_get_platform(struct wpe_renderer_backend_egl*);
 
 WPE_EXPORT
 struct wpe_renderer_backend_egl_target*

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -61,6 +61,14 @@ wpe_renderer_backend_egl_get_native_display(struct wpe_renderer_backend_egl* bac
     return backend->interface->get_native_display(backend->interface_data);
 }
 
+uint32_t
+wpe_renderer_backend_egl_get_platform(struct wpe_renderer_backend_egl* backend)
+{
+    if (backend->interface->get_platform)
+        return backend->interface->get_platform(backend->interface_data);
+    return 0;
+}
+
 struct wpe_renderer_backend_egl_target*
 wpe_renderer_backend_egl_target_create(int host_fd)
 {


### PR DESCRIPTION
wpe_renderer_backend_egl_get_display_platform will return either :
- a platform to give to eglGetPlatformDisplay / eglGetPlatformDisplayEXT
- 0 (default if get_display_platform isn't implemented) if we must only use eglGetDisplay

This is needed on new Broadcom STB reference software, where both both client (wayland-egl)
and server (nexus) platforms are in the same library.