### PR TITLE
Add version-deprecated.h in DERIVED_SOURCES_DIR (CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 set(DERIVED_SOURCES_DIR "${CMAKE_BINARY_DIR}/DerivedSources/wpe")
 configure_file(include/wpe/version.h.cmake ${DERIVED_SOURCES_DIR}/version.h @ONLY)
+configure_file(include/wpe/version-deprecated.h.cmake ${DERIVED_SOURCES_DIR}/version-deprecated.h @ONLY)
 
 include(DistTargets)
 include(GNUInstallDirs)
@@ -64,6 +65,7 @@ set(WPE_SOURCES
 
 set(WPE_PUBLIC_HEADERS
   ${DERIVED_SOURCES_DIR}/version.h
+  ${DERIVED_SOURCES_DIR}/version-deprecated.h
   include/wpe/export.h
   include/wpe/input.h
   include/wpe/keysyms.h


### PR DESCRIPTION
Fixes this build error introduced in https://github.com/WebPlatformForEmbedded/libwpe/pull/38

**FAILED**: https://gitlab.com/saavedra.pablo/meta-perf-browser/-/jobs/128198467

```
| "/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-gcc" -DWPE_COMPILATION -Dwpe_EXPORTS -I"/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/git/include" -I"/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/git/src" -IDerivedSources/wpe -I"/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/recipe-sysroot/usr/include" -march=armv7-a -marm -mfpu=neon -mfloat-abi=hard -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0=/usr/src/debug/libwpe/1.0~git-r0 -fdebug-prefix-map=/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/recipe-sysroot= -fdebug-prefix-map=/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/recipe-sysroot-native=   -march=armv7-a -marm -mfpu=neon -mfloat-abi=hard -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/recipe-sysroot -std=c99 -D_POSIX_SOURCE -fPIC -MD -MT CMakeFiles/wpe.dir/src/version.c.o -MF CMakeFiles/wpe.dir/src/version.c.o.d -o CMakeFiles/wpe.dir/src/version.c.o   -c '/home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/git/src/version.c'
| /home/igalia/psaavedra/yocto-wandboard-wpe/builds/wandboard-mesa-wpe-alternative/tmp/work/armv7ahf-neon-imx-poky-linux-gnueabi/libwpe/1.0~git-r0/git/src/version.c:28:10: fatal error: version-deprecated.h: No such file or directory
|  #include "version-deprecated.h"
|           ^~~~~~~~~~~~~~~~~~~~~~
| compilation terminated.
```

Full log: https://gitlab-artifacts.s3.amazonaws.com/26/9b/269be52fa73e7fb2b7c67b1556958dba98cfe48530678548f6a42fa93dcb9090/2018_12_01/128198466/123427560/job.log?response-content-type=text/plain%3B%20charset%3Dutf-8&response-content-disposition=inline&X-Amz-Expires=600&X-Amz-Date=20181201T064520Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJTOFWQ3GL4O3Q3FA/20181201/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=e470594f0fad89a4ef2658475a8b002a529827e1f371b4909d76e03e10221afd

