### PR TITLE
Fix leaks on failure to obtain backend interface implementation

### DIFF
--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -38,8 +38,10 @@ wpe_renderer_backend_egl_create(int host_fd)
         return 0;
 
     backend->interface = wpe_load_object("_wpe_renderer_backend_egl_interface");
-    if (!backend->interface)
+    if (!backend->interface) {
+        free(backend);
         return 0;
+    }
 
     backend->interface_data = backend->interface->create(host_fd);
 
@@ -77,8 +79,10 @@ wpe_renderer_backend_egl_target_create(int host_fd)
         return 0;
 
     target->interface = wpe_load_object("_wpe_renderer_backend_egl_target_interface");
-    if (!target->interface)
+    if (!target->interface) {
+        free(target);
         return 0;
+    }
 
     target->interface_data = target->interface->create(target, host_fd);
 
@@ -142,8 +146,10 @@ wpe_renderer_backend_egl_offscreen_target_create()
         return 0;
 
     target->interface = wpe_load_object("_wpe_renderer_backend_egl_offscreen_target_interface");
-    if (!target->interface)
+    if (!target->interface) {
+        free(target);
         return 0;
+    }
 
     target->interface_data = target->interface->create();
 


### PR DESCRIPTION
If `wpe_load_object()` fails to obtain the implementation for interfaces, free the `struct` before the early error returns instead of leaking them.