### PR TITLE
CI: Add basic Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: python
+dist: xenial
+sudo: false
+
+git:
+  depth: false
+  quiet: true
+
+addons:
+  apt:
+    packages:
+      - cmake
+      - libegl1-mesa-dev
+      - libjson-glib-dev
+      - libxkbcommon-dev
+      - ninja-build
+
+python:
+  - "3.7"
+
+env:
+  matrix:
+    - BUILD_TYPE=Debug   BUILD_DOCS=OFF
+    - BUILD_TYPE=Release BUILD_DOCS=ON
+
+cache:
+  - ccache
+  - pip
+
+install: |-
+  : 'Install HotDoc if needed'
+  if [[ ${BUILD_DOCS} = ON ]] ; then
+    pip install HotDoc
+  fi
+
+script: |-
+  : 'Build'
+  set -e
+  mkdir _build && cd $_
+  cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_DOCS=${BUILD_DOCS}
+  TERM=dumb cmake --build . --parallel $(nproc)


### PR DESCRIPTION
This adds a simple configuration that builds `libwpe` on Ubuntu Xenial. It would be good to have to make sure that PRs at least don't break the build.

----

Sample builds (done in the repository clone in my GitHub account:

- https://travis-ci.com/aperezdc/libwpe/jobs/222060784
- https://travis-ci.com/aperezdc/libwpe/jobs/222060785

----

I have sent a request for the owners of the WebPlatformForEmbedded organization to approve adding Travis-CI for this repository—if one of @albertd, @carlosgcampos, @magomez, @modeveci,, @oscaruitenbroek, @pwielders, @wouterlucas, or @zdobersek could approve it, that would be super. Thanks in advance!