### PR TITLE
Multiple CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,11 @@ set(WPE_INCLUDE_DIRECTORIES
     "include"
     "src"
     ${DERIVED_SOURCES_DIR}
-    ${LIBXKBCOMMON_INCLUDE_DIRS}
 )
 
 set(WPE_LIBRARIES
     dl
-    ${LIBXKBCOMMON_LIBRARIES}
+    XkbCommon::libxkbcommon
 )
 
 set(WPE_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
 target_compile_options(wpe PRIVATE
     $<TARGET_PROPERTY:GL::egl,INTERFACE_COMPILE_OPTIONS>
 )
-target_link_libraries(wpe PUBLIC ${WPE_LIBRARIES})
+target_link_libraries(wpe PRIVATE ${WPE_LIBRARIES})
 
 set_target_properties(wpe PROPERTIES
   OUTPUT_NAME wpe-${WPE_API_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ include(GNUInstallDirs)
 find_package(EGL REQUIRED)
 find_package(Libxkbcommon REQUIRED)
 
-add_definitions(-DWPE_COMPILATION)
-
 set(WPE_INCLUDE_DIRECTORIES
     "include"
     "src"
@@ -99,6 +97,7 @@ target_include_directories(wpe PRIVATE
     $<TARGET_PROPERTY:GL::egl,INTERFACE_INCLUDE_DIRECTORIES>
 )
 target_compile_definitions(wpe PRIVATE
+    WPE_COMPILATION
     $<TARGET_PROPERTY:GL::egl,INTERFACE_COMPILE_DEFINITIONS>
 )
 if (WPE_BACKEND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(LIBWPE 3 1 2)
 
 project(libwpe VERSION "${PROJECT_VERSION}")
 
+set(WPE_BACKEND "" CACHE STRING
+    "Name of the backend library to load, instead of libWPEBackend-default.so")
+
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
@@ -49,10 +52,6 @@ find_package(EGL REQUIRED)
 find_package(Libxkbcommon REQUIRED)
 
 add_definitions(-DWPE_COMPILATION)
-
-if(WPE_BACKEND)
-  add_definitions(-DWPE_BACKEND=\"${WPE_BACKEND}\")
-endif()
 
 set(WPE_INCLUDE_DIRECTORIES
     "include"
@@ -102,6 +101,9 @@ target_include_directories(wpe PRIVATE
 target_compile_definitions(wpe PRIVATE
     $<TARGET_PROPERTY:GL::egl,INTERFACE_COMPILE_DEFINITIONS>
 )
+if (WPE_BACKEND)
+    target_compile_definitions(wpe PRIVATE WPE_BACKEND=\"${WPE_BACKEND}\")
+endif()
 target_compile_options(wpe PRIVATE
     $<TARGET_PROPERTY:GL::egl,INTERFACE_COMPILE_OPTIONS>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ include(GNUInstallDirs)
 find_package(EGL REQUIRED)
 find_package(Libxkbcommon REQUIRED)
 
-add_definitions(${EGL_DEFINITIONS})
 add_definitions(-DWPE_COMPILATION)
 
 if(WPE_BACKEND)
@@ -59,7 +58,6 @@ set(WPE_INCLUDE_DIRECTORIES
     "include"
     "src"
     ${DERIVED_SOURCES_DIR}
-    ${EGL_INCLUDE_DIRS}
     ${LIBXKBCOMMON_INCLUDE_DIRS}
 )
 
@@ -97,8 +95,17 @@ set(WPE_PUBLIC_HEADERS
 )
 
 add_library(wpe SHARED ${WPE_SOURCES})
-target_include_directories(wpe PRIVATE ${WPE_INCLUDE_DIRECTORIES})
-target_link_libraries(wpe ${WPE_LIBRARIES})
+target_include_directories(wpe PRIVATE
+    ${WPE_INCLUDE_DIRECTORIES}
+    $<TARGET_PROPERTY:GL::egl,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_compile_definitions(wpe PRIVATE
+    $<TARGET_PROPERTY:GL::egl,INTERFACE_COMPILE_DEFINITIONS>
+)
+target_compile_options(wpe PRIVATE
+    $<TARGET_PROPERTY:GL::egl,INTERFACE_COMPILE_OPTIONS>
+)
+target_link_libraries(wpe PUBLIC ${WPE_LIBRARIES})
 
 set_target_properties(wpe PROPERTIES
   OUTPUT_NAME wpe-${WPE_API_VERSION}

--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -1,13 +1,12 @@
 # - Try to Find EGL
 # Once done, this will define
 #
-#  EGL_FOUND - system has EGL installed.
-#  EGL_INCLUDE_DIRS - directories which contain the EGL headers.
-#  EGL_LIBRARIES - libraries required to link against EGL.
-#  EGL_DEFINITIONS - Compiler switches required for using EGL.
+#  GL::egl - an imported library target.
+#  EGL_FOUND - a boolean variable.
+#  EGL_INCLUDE_DIR - directory containing the EGL/egl.h header.
+#  EGL_LIBRARY - path to the EGL library.
 #
-# Copyright (C) 2012 Intel Corporation. All rights reserved.
-# Copyright (C) 2017 Igalia S.L.
+# Copyright (C) 2019 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,20 +31,33 @@
 
 
 find_package(PkgConfig)
+pkg_check_modules(EGL IMPORTED_TARGET egl)
 
-pkg_check_modules(PC_EGL egl)
+find_path(EGL_INCLUDE_DIR
+    NAMES EGL/egl.h
+    HINTS ${EGL_INCLUDEDIR} ${EGL_INCLUDE_DIRS}
+)
+find_library(EGL_LIBRARY
+    NAMES egl EGL
+    HINTS ${EGL_LIBDIR} ${EGL_LIBRARY_DIRS}
+)
+mark_as_advanced(EGL_INCLUDE_DIR EGL_LIBRARY)
 
-if (PC_EGL_FOUND)
-    set(EGL_DEFINITIONS ${PC_EGL_CFLAGS_OTHER})
+# If pkg-config has not found the module but find_path+find_library have
+# figured out where the header and library are, create the PkgConfig::EGL
+# imported target anyway with the found paths.
+#
+if (EGL_LIBRARIES AND NOT TARGET GL::egl)
+    add_library(GL::egl INTERFACE IMPORTED)
+    if (TARGET PkgConfig::EGL)
+        target_link_libraries(GL::egl INTERFACE PkgConfig::EGL)
+    else ()
+        set_property(TARGET GL::egl PROPERTY
+            INTERFACE_LINK_LIBRARIES ${EGL_LIBRARY})
+        set_property(TARGET GL::egl PROPERTY
+            INTERFACE_INCLUDE_DIRECTORIES ${EGL_INCLUDE_DIR})
+    endif ()
 endif ()
 
-find_path(EGL_INCLUDE_DIRS NAMES EGL/eglplatform.h
-    HINTS ${PC_EGL_INCLUDEDIR} ${PC_EGL_INCLUDE_DIRS}
-)
-
-set(EGL_INCLUDE_DIRS ${PC_EGL_INCLUDE_DIRS} CACHE FILEPATH "FIXME")
-
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(EGL DEFAULT_MSG EGL_INCLUDE_DIRS)
-
-mark_as_advanced(EGL_INCLUDE_DIRS)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(EGL REQUIRED_VARS EGL_LIBRARY EGL_INCLUDE_DIR)

--- a/cmake/FindLibxkbcommon.cmake
+++ b/cmake/FindLibxkbcommon.cmake
@@ -1,11 +1,12 @@
 # - Try to find libxkbcommon.
 # Once done, this will define
 #
+#  XkbCommon::libxkbcommon
 #  LIBXKBCOMMON_FOUND - system has libxkbcommon.
-#  LIBXKBCOMMON_INCLUDE_DIRS - the libxkbcommon include directories
-#  LIBXKBCOMMON_LIBRARIES - link these to use libxkbcommon.
+#  LIBXKBCOMMON_INCLUDE_DIR - directory containing the xkbcommon include directories
+#  LIBXKBCOMMON_LIBRARY - link these to use libxkbcommon.
 #
-# Copyright (C) 2014 Igalia S.L.
+# Copyright (C) 2014, 2019 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,8 +30,34 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_package(PkgConfig)
-pkg_check_modules(LIBXKBCOMMON xkbcommon)
+pkg_check_modules(LIBXKBCOMMON IMPORTED_TARGET xkbcommon)
+
+find_path(LIBXKBCOMMON_INCLUDE_DIR
+    NAMES xkbcommon/xkbcommon.h
+    HINTS ${LIBXKBCOMMON_INCLUDEDIR} ${LIBXKBCOMMON_INCLUDE_DIRS}
+)
+find_library(LIBXKBCOMMON_LIBRARY
+    NAMES xkbcommon
+    HINTS ${LIBXKBCOMMON_LIBDIR} ${LIBXKBCOMMON_LIBRARY_DIRS}
+)
+
+# If pkg-config has not found the module but find_path+find_library have
+# figured out where the header and library are, create the
+# XkbCommon::Libxkbcommon imported target anyway with the found paths.
+#
+if (LIBXKBCOMMON_LIBRARY AND NOT TARGET XkbCommon::libxkbcommon)
+    add_library(XkbCommon::libxkbcommon INTERFACE IMPORTED)
+    if (TARGET PkgConfig::LIBXKBCOMMON)
+        target_link_libraries(XkbCommon::libxkbcommon INTERFACE PkgConfig::LIBXKBCOMMON)
+    else ()
+        set_property(TARGET XkbCommon::libxkbcommon PROPERTY
+            INTERFACE_LINK_LIBRARIES ${LIBXKBCOMMON_LIBRARY})
+        set_property(TARGET XkbCommon::libxkbcommon PROPERTY
+            INTERFACE_INCLUDE_DIRECTORIES ${LIBXKBCOMMON_INCLUDE_DIR})
+    endif ()
+endif ()
+
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libxkbcommon REQUIRED_VARS LIBXKBCOMMON_FOUND
-                                  FOUND_VAR LIBXKBCOMMON_FOUND)
+find_package_handle_standard_args(LIBXKBCOMMON REQUIRED_VARS
+    LIBXKBCOMMON_LIBRARY LIBXKBCOMMON_INCLUDE_DIR)


### PR DESCRIPTION
Namely:

* Use an imported library for `FindEGL.cmake` (copied from https://github.com/Igalia/WPEBackend-fdo/pull/69).
* Use an imported library for `FindLibxkbcommon.cmake` (same idea as the previous one).
* Set definitions per-target using `target_compile_definitions()`, instead of setting them globally with `add_definitions()`.
* Mark libraries linked into `libwpe` as `PRIVATE`.