### PR TITLE
Add public base structs for the main API objects

### DIFF
--- a/include/wpe/renderer-backend-egl.h
+++ b/include/wpe/renderer-backend-egl.h
@@ -67,6 +67,11 @@ struct wpe_renderer_backend_egl_interface {
     void (*_wpe_reserved3)(void);
 };
 
+struct wpe_renderer_backend_egl_base {
+    const struct wpe_renderer_backend_egl_interface* interface;
+    void* interface_data;
+};
+
 struct wpe_renderer_backend_egl_target_interface {
     void* (*create)(struct wpe_renderer_backend_egl_target*, int);
     void (*destroy)(void*);
@@ -84,6 +89,11 @@ struct wpe_renderer_backend_egl_target_interface {
     void (*_wpe_reserved3)(void);
 };
 
+struct wpe_renderer_backend_egl_target_base {
+    const struct wpe_renderer_backend_egl_target_interface* interface;
+    void* interface_data;
+};
+
 struct wpe_renderer_backend_egl_offscreen_target_interface {
     void* (*create)();
     void (*destroy)(void*);
@@ -97,6 +107,12 @@ struct wpe_renderer_backend_egl_offscreen_target_interface {
     void (*_wpe_reserved2)(void);
     void (*_wpe_reserved3)(void);
 };
+
+struct wpe_renderer_backend_egl_offscreen_target_base {
+    const struct wpe_renderer_backend_egl_offscreen_target_interface* interface;
+    void* interface_data;
+};
+
 
 WPE_EXPORT
 struct wpe_renderer_backend_egl*

--- a/include/wpe/renderer-host.h
+++ b/include/wpe/renderer-host.h
@@ -58,6 +58,11 @@ struct wpe_renderer_host_interface {
     void (*_wpe_reserved3)(void);
 };
 
+struct wpe_renderer_host_base {
+    const struct wpe_renderer_host_interface* interface;
+    void* interface_data;
+};
+
 WPE_EXPORT
 int
 wpe_renderer_host_create_client();

--- a/include/wpe/view-backend.h
+++ b/include/wpe/view-backend.h
@@ -71,6 +71,11 @@ struct wpe_view_backend_interface {
     void (*_wpe_reserved3)(void);
 };
 
+struct wpe_view_backend_base {
+    const struct wpe_view_backend_interface* interface;
+    void* interface_data;
+};
+
 
 WPE_EXPORT
 struct wpe_view_backend*

--- a/src/renderer-backend-egl-private.h
+++ b/src/renderer-backend-egl-private.h
@@ -28,21 +28,18 @@
 #define wpe_renderer_backend_egl_private_h
 
 struct wpe_renderer_backend_egl {
-    const struct wpe_renderer_backend_egl_interface* interface;
-    void* interface_data;
+    struct wpe_renderer_backend_egl_base base;
 };
 
 struct wpe_renderer_backend_egl_target {
-    const struct wpe_renderer_backend_egl_target_interface* interface;
-    void* interface_data;
+    struct wpe_renderer_backend_egl_target_base base;
 
     const struct wpe_renderer_backend_egl_target_client* client;
     void* client_data;
 };
 
 struct wpe_renderer_backend_egl_offscreen_target {
-    const struct wpe_renderer_backend_egl_offscreen_target_interface* interface;
-    void* interface_data;
+    struct wpe_renderer_backend_egl_offscreen_target_base base;
 };
 
 #endif // wpe_renderer_backend_egl_private_h

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -37,13 +37,13 @@ wpe_renderer_backend_egl_create(int host_fd)
     if (!backend)
         return 0;
 
-    backend->interface = wpe_load_object("_wpe_renderer_backend_egl_interface");
-    if (!backend->interface) {
+    backend->base.interface = wpe_load_object("_wpe_renderer_backend_egl_interface");
+    if (!backend->base.interface) {
         free(backend);
         return 0;
     }
 
-    backend->interface_data = backend->interface->create(host_fd);
+    backend->base.interface_data = backend->base.interface->create(host_fd);
 
     return backend;
 }
@@ -51,8 +51,8 @@ wpe_renderer_backend_egl_create(int host_fd)
 void
 wpe_renderer_backend_egl_destroy(struct wpe_renderer_backend_egl* backend)
 {
-    backend->interface->destroy(backend->interface_data);
-    backend->interface_data = 0;
+    backend->base.interface->destroy(backend->base.interface_data);
+    backend->base.interface_data = 0;
 
     free(backend);
 }
@@ -60,14 +60,14 @@ wpe_renderer_backend_egl_destroy(struct wpe_renderer_backend_egl* backend)
 EGLNativeDisplayType
 wpe_renderer_backend_egl_get_native_display(struct wpe_renderer_backend_egl* backend)
 {
-    return backend->interface->get_native_display(backend->interface_data);
+    return backend->base.interface->get_native_display(backend->base.interface_data);
 }
 
 uint32_t
 wpe_renderer_backend_egl_get_platform(struct wpe_renderer_backend_egl* backend)
 {
-    if (backend->interface->get_platform)
-        return backend->interface->get_platform(backend->interface_data);
+    if (backend->base.interface->get_platform)
+        return backend->base.interface->get_platform(backend->base.interface_data);
     return 0;
 }
 
@@ -78,13 +78,13 @@ wpe_renderer_backend_egl_target_create(int host_fd)
     if (!target)
         return 0;
 
-    target->interface = wpe_load_object("_wpe_renderer_backend_egl_target_interface");
-    if (!target->interface) {
+    target->base.interface = wpe_load_object("_wpe_renderer_backend_egl_target_interface");
+    if (!target->base.interface) {
         free(target);
         return 0;
     }
 
-    target->interface_data = target->interface->create(target, host_fd);
+    target->base.interface_data = target->base.interface->create(target, host_fd);
 
     return target;
 }
@@ -92,8 +92,8 @@ wpe_renderer_backend_egl_target_create(int host_fd)
 void
 wpe_renderer_backend_egl_target_destroy(struct wpe_renderer_backend_egl_target* target)
 {
-    target->interface->destroy(target->interface_data);
-    target->interface_data = 0;
+    target->base.interface->destroy(target->base.interface_data);
+    target->base.interface_data = 0;
 
     target->client = 0;
     target->client_data = 0;
@@ -111,31 +111,31 @@ wpe_renderer_backend_egl_target_set_client(struct wpe_renderer_backend_egl_targe
 void
 wpe_renderer_backend_egl_target_initialize(struct wpe_renderer_backend_egl_target* target, struct wpe_renderer_backend_egl* backend, uint32_t width, uint32_t height)
 {
-    target->interface->initialize(target->interface_data, backend->interface_data, width, height);
+    target->base.interface->initialize(target->base.interface_data, backend->base.interface_data, width, height);
 }
 
 EGLNativeWindowType
 wpe_renderer_backend_egl_target_get_native_window(struct wpe_renderer_backend_egl_target* target)
 {
-    return target->interface->get_native_window(target->interface_data);
+    return target->base.interface->get_native_window(target->base.interface_data);
 }
 
 void
 wpe_renderer_backend_egl_target_resize(struct wpe_renderer_backend_egl_target* target, uint32_t width, uint32_t height)
 {
-    target->interface->resize(target->interface_data, width, height);
+    target->base.interface->resize(target->base.interface_data, width, height);
 }
 
 void
 wpe_renderer_backend_egl_target_frame_will_render(struct wpe_renderer_backend_egl_target* target)
 {
-    target->interface->frame_will_render(target->interface_data);
+    target->base.interface->frame_will_render(target->base.interface_data);
 }
 
 void
 wpe_renderer_backend_egl_target_frame_rendered(struct wpe_renderer_backend_egl_target* target)
 {
-    target->interface->frame_rendered(target->interface_data);
+    target->base.interface->frame_rendered(target->base.interface_data);
 }
 
 struct wpe_renderer_backend_egl_offscreen_target*
@@ -145,13 +145,13 @@ wpe_renderer_backend_egl_offscreen_target_create()
     if (!target)
         return 0;
 
-    target->interface = wpe_load_object("_wpe_renderer_backend_egl_offscreen_target_interface");
-    if (!target->interface) {
+    target->base.interface = wpe_load_object("_wpe_renderer_backend_egl_offscreen_target_interface");
+    if (!target->base.interface) {
         free(target);
         return 0;
     }
 
-    target->interface_data = target->interface->create();
+    target->base.interface_data = target->base.interface->create();
 
     return target;
 }
@@ -159,8 +159,8 @@ wpe_renderer_backend_egl_offscreen_target_create()
 void
 wpe_renderer_backend_egl_offscreen_target_destroy(struct wpe_renderer_backend_egl_offscreen_target* target)
 {
-    target->interface->destroy(target->interface_data);
-    target->interface_data = 0;
+    target->base.interface->destroy(target->base.interface_data);
+    target->base.interface_data = 0;
 
     free(target);
 }
@@ -168,13 +168,13 @@ wpe_renderer_backend_egl_offscreen_target_destroy(struct wpe_renderer_backend_eg
 void
 wpe_renderer_backend_egl_offscreen_target_initialize(struct wpe_renderer_backend_egl_offscreen_target* target, struct wpe_renderer_backend_egl* backend)
 {
-    target->interface->initialize(target->interface_data, backend->interface_data);
+    target->base.interface->initialize(target->base.interface_data, backend->base.interface_data);
 }
 
 EGLNativeWindowType
 wpe_renderer_backend_egl_offscreen_target_get_native_window(struct wpe_renderer_backend_egl_offscreen_target* target)
 {
-    return target->interface->get_native_window(target->interface_data);
+    return target->base.interface->get_native_window(target->base.interface_data);
 }
 
 void

--- a/src/renderer-host-private.h
+++ b/src/renderer-host-private.h
@@ -27,13 +27,14 @@
 #ifndef wpe_renderer_host_private_h
 #define wpe_renderer_host_private_h
 
+#include <wpe/renderer-host.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct wpe_renderer_host {
-    const struct wpe_renderer_host_interface* interface;
-    void* interface_data;
+    struct wpe_renderer_host_base base;
 };
 
 #ifdef __cplusplus

--- a/src/renderer-host.c
+++ b/src/renderer-host.c
@@ -24,10 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/renderer-host.h>
+#include "renderer-host-private.h"
 
 #include "loader-private.h"
-#include "renderer-host-private.h"
 #include <stdlib.h>
 
 int
@@ -39,11 +38,11 @@ wpe_renderer_host_create_client()
         if (!s_renderer_host)
             return -1;
 
-        s_renderer_host->interface = wpe_load_object("_wpe_renderer_host_interface");
-        s_renderer_host->interface_data = s_renderer_host->interface->create();
+        s_renderer_host->base.interface = wpe_load_object("_wpe_renderer_host_interface");
+        s_renderer_host->base.interface_data = s_renderer_host->base.interface->create();
 
         // FIXME: atexit() should clean up the object.
     }
 
-    return s_renderer_host->interface->create_client(s_renderer_host->interface_data);
+    return s_renderer_host->base.interface->create_client(s_renderer_host->base.interface_data);
 }

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -34,8 +34,7 @@ extern "C" {
 #endif
 
 struct wpe_view_backend {
-    const struct wpe_view_backend_interface* interface;
-    void* interface_data;
+    struct wpe_view_backend_base base;
 
     const struct wpe_view_backend_client* backend_client;
     void* backend_client_data;

--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -24,10 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/view-backend.h>
+#include "view-backend-private.h"
 
 #include "loader-private.h"
-#include "view-backend-private.h"
 #include <stdlib.h>
 
 
@@ -48,8 +47,8 @@ wpe_view_backend_create_with_backend_interface(struct wpe_view_backend_interface
     if (!backend)
         return 0;
 
-    backend->interface = interface;
-    backend->interface_data = backend->interface->create(interface_user_data, backend);
+    backend->base.interface = interface;
+    backend->base.interface_data = backend->base.interface->create(interface_user_data, backend);
 
     return backend;
 }
@@ -57,8 +56,8 @@ wpe_view_backend_create_with_backend_interface(struct wpe_view_backend_interface
 void
 wpe_view_backend_destroy(struct wpe_view_backend* backend)
 {
-    backend->interface->destroy(backend->interface_data);
-    backend->interface_data = 0;
+    backend->base.interface->destroy(backend->base.interface_data);
+    backend->base.interface_data = 0;
 
     backend->backend_client = 0;
     backend->backend_client_data = 0;
@@ -97,13 +96,13 @@ wpe_view_backend_set_input_client(struct wpe_view_backend* backend, const struct
 void
 wpe_view_backend_initialize(struct wpe_view_backend* backend)
 {
-    backend->interface->initialize(backend->interface_data);
+    backend->base.interface->initialize(backend->base.interface_data);
 }
 
 int
 wpe_view_backend_get_renderer_host_fd(struct wpe_view_backend* backend)
 {
-    return backend->interface->get_renderer_host_fd(backend->interface_data);
+    return backend->base.interface->get_renderer_host_fd(backend->base.interface_data);
 }
 
 void


### PR DESCRIPTION
Add base structs for the majority of API objects. This allows
implementation libraries to cast such objects to pointers to these
base structs, providing easier access to the implementation-specific
interface data.