### PR TITLE
axis events

### DIFF
--- a/include/wpe/input.h
+++ b/include/wpe/input.h
@@ -94,7 +94,7 @@ enum wpe_input_axis_event_type {
     wpe_input_axis_event_type_motion,
     wpe_input_axis_event_type_motion_smooth,
 
-    wpe_input_axis_event_type_2d = 1 << 16,
+    wpe_input_axis_event_type_mask_2d = 1 << 16,
 };
 
 struct wpe_input_axis_event {

--- a/include/wpe/input.h
+++ b/include/wpe/input.h
@@ -93,6 +93,8 @@ enum wpe_input_axis_event_type {
     wpe_input_axis_event_type_null,
     wpe_input_axis_event_type_motion,
     wpe_input_axis_event_type_motion_smooth,
+
+    wpe_input_axis_event_type_2d = 1 << 16,
 };
 
 struct wpe_input_axis_event {
@@ -103,6 +105,13 @@ struct wpe_input_axis_event {
     uint32_t axis;
     int32_t value;
     uint32_t modifiers;
+};
+
+struct wpe_input_axis_2d_event {
+    struct wpe_input_axis_event base;
+
+    double x_axis;
+    double y_axis;
 };
 
 

--- a/include/wpe/input.h
+++ b/include/wpe/input.h
@@ -92,6 +92,7 @@ struct wpe_input_pointer_event {
 enum wpe_input_axis_event_type {
     wpe_input_axis_event_type_null,
     wpe_input_axis_event_type_motion,
+    wpe_input_axis_event_type_motion_smooth,
 };
 
 struct wpe_input_axis_event {


### PR DESCRIPTION
- wpe_input_axis_event_type_motion_smooth allows for axis events whose delta translates directly to scrolling value
- wpe_input_axis_2d_event allows combining x/y deltas in a single event