### PR TITLE
 CMake: Use "hidden" symbol visibility by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ target_compile_options(wpe PRIVATE
 target_link_libraries(wpe PRIVATE XkbCommon::libxkbcommon ${CMAKE_DL_LIBS})
 
 set_target_properties(wpe PROPERTIES
+  C_VISIBILITY_PRESET hidden
+  CXX_VISIBILITY_PRESET hidden
   OUTPUT_NAME wpe-${WPE_API_VERSION}
   VERSION ${LIBWPE_VERSION}
   SOVERSION ${LIBWPE_VERSION_MAJOR}


### PR DESCRIPTION
Arrange passing `-fvisibility=hidden` to the compiler where supported, which effectively disables exporting symbols which are not explicitly marked as visible.

No further changes are needed because the public API functions were already marked with `WPE_EXPORT` which marks them as exported.