### PR TITLE
CI: Update image to Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Bump the version of the Ubuntu image used for CI builds to 18.04, which is the previous-to-last LTS version currently available, and the oldest system where building libwpe is currently supported.