### PR TITLE
meson: Use a partial dependency to pass EGL module flags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,8 +57,16 @@ dependencies = [
 ]
 
 cc = meson.get_compiler('c')
-if not cc.has_header('EGL/eglplatform.h')
-	dependencies += dependency('egl')
+egl_dep = dependency('egl', required: false)
+if egl_dep.found()
+	dependencies += egl_dep.partial_dependency(
+		compile_args: true,
+		includes: true,
+	)
+else
+	assert(cc.has_header('EGL/eglplatform.h'),
+		'Required header <EGL/eglplatform.h> not found'
+	)
 endif
 
 if not cc.has_function('dlopen')


### PR DESCRIPTION
Make Meson try to always find an `egl` dependency, if found extract the include directories and compiler flags from ir using a partial dependency, otherwise check that at least `EGL/eglplatform.h` is available when the pkg-config module is not found.

Fixes #70