### PR TITLE
meson: Expose dependency for use as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -152,3 +152,8 @@ if get_option('build-docs')
 		extra_c_flags: [' -DWPE_COMPILATION=1'],
 	)
 endif
+
+libwpe_dep = declare_dependency(link_with : libwpe,
+  include_directories : include_directories('include'),
+  dependencies : dependencies,
+)


### PR DESCRIPTION
This is needed so that WPEBackend-FDO and/or gst-build could fallback to build
libwpe as subproject if its version on the host system is too old.