### PR TITLE
Fix using libwpe as meson subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ add_library(wpe SHARED
 target_include_directories(wpe PRIVATE
     "include"
     "src"
-    ${DERIVED_SOURCES_DIR}
+    ${DERIVED_SOURCES_DIR}/..
     $<TARGET_PROPERTY:GL::egl,INTERFACE_INCLUDE_DIRECTORIES>
 )
 target_compile_definitions(wpe PRIVATE

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,1 @@
+subdir('wpe')

--- a/include/wpe/meson.build
+++ b/include/wpe/meson.build
@@ -1,0 +1,28 @@
+api_headers = [
+	'export.h',
+	'input.h',
+	'keysyms.h',
+	'loader.h',
+	'pasteboard.h',
+	'renderer-backend-egl.h',
+	'renderer-host.h',
+	'view-backend.h',
+	'wpe-egl.h',
+	'wpe.h',
+
+	# Generated API headers.
+	configure_file(
+		input: 'version.h.cmake',
+		output: 'version.h',
+		configuration: version_info,
+	),
+	configure_file(
+		input: 'version-deprecated.h.cmake',
+		output: 'version-deprecated.h',
+		configuration: version_info,
+	),
+]
+install_headers(api_headers,
+	subdir: join_paths('wpe-' + api_version, 'wpe'),
+)
+

--- a/include/wpe/wpe.h
+++ b/include/wpe/wpe.h
@@ -34,15 +34,15 @@
 
 #define __WPE_H_INSIDE__
 
-#include "export.h"
-#include "input.h"
-#include "keysyms.h"
-#include "loader.h"
-#include "pasteboard.h"
-#include "renderer-host.h"
-#include "version.h"
-#include "version-deprecated.h"
-#include "view-backend.h"
+#include "wpe/export.h"
+#include "wpe/input.h"
+#include "wpe/keysyms.h"
+#include "wpe/loader.h"
+#include "wpe/pasteboard.h"
+#include "wpe/renderer-host.h"
+#include "wpe/version.h"
+#include "wpe/version-deprecated.h"
+#include "wpe/view-backend.h"
 
 #undef __WPE_H_INSIDE__
 

--- a/meson.build
+++ b/meson.build
@@ -90,36 +90,10 @@ libwpe = library('wpe-' + api_version,
 	soversion: soversion_major,
 	include_directories: 'include',
 	gnu_symbol_visibility: 'hidden',
+	include_directories : [include_directories('include')],
 )
 
-api_headers = [
-	'include/wpe/export.h',
-	'include/wpe/input.h',
-	'include/wpe/keysyms.h',
-	'include/wpe/loader.h',
-	'include/wpe/pasteboard.h',
-	'include/wpe/renderer-backend-egl.h',
-	'include/wpe/renderer-host.h',
-	'include/wpe/view-backend.h',
-	'include/wpe/wpe-egl.h',
-	'include/wpe/wpe.h',
-
-	# Generated API headers.
-	configure_file(
-		input: 'include/wpe/version.h.cmake',
-		output: 'version.h',
-		configuration: version_info,
-	),
-	configure_file(
-		input: 'include/wpe/version-deprecated.h.cmake',
-		output: 'version-deprecated.h',
-		configuration: version_info,
-	),
-]
-install_headers(api_headers,
-	subdir: join_paths('wpe-' + api_version, 'wpe'),
-)
-
+subdir('include')
 import('pkgconfig').generate(
 	description: 'The wpe library',
 	name: 'wpe-' + api_version,

--- a/src/version.c
+++ b/src/version.c
@@ -24,8 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "version.h"
-#include "version-deprecated.h"
+#include "wpe/version.h"
+#include "wpe/version-deprecated.h"
 
 unsigned
 wpe_get_major_version(void)


### PR DESCRIPTION
We basically need to make sure that both `<builddir>/include>` and
`include/` are usable as include directory and we need to avoid
exposing the directory with `version.h` to the outside world
when linking as a subproject as that clashes easily (at least with
wpeframework-fdo).