### PR TITLE
Prefer local header includes

### DIFF
--- a/include/wpe/input.h
+++ b/include/wpe/input.h
@@ -38,7 +38,7 @@
  */
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "export.h"
 #endif
 
 #include <stdbool.h>

--- a/include/wpe/loader.h
+++ b/include/wpe/loader.h
@@ -38,7 +38,7 @@
  */
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "export.h"
 #endif
 
 #include <stdbool.h>

--- a/include/wpe/pasteboard.h
+++ b/include/wpe/pasteboard.h
@@ -38,7 +38,7 @@
  */
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "export.h"
 #endif
 
 #include <stdint.h>

--- a/include/wpe/renderer-backend-egl.h
+++ b/include/wpe/renderer-backend-egl.h
@@ -38,7 +38,7 @@
  */
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "export.h"
 #endif
 
 #include <EGL/eglplatform.h>

--- a/include/wpe/renderer-host.h
+++ b/include/wpe/renderer-host.h
@@ -38,7 +38,7 @@
  */
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "export.h"
 #endif
 
 #ifdef __cplusplus

--- a/include/wpe/version-deprecated.h.cmake
+++ b/include/wpe/version-deprecated.h.cmake
@@ -32,7 +32,7 @@
 #define wpe_version_deprecated_h
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "wpe/export.h"
 #endif
 
 #ifdef __cplusplus

--- a/include/wpe/version.h.cmake
+++ b/include/wpe/version.h.cmake
@@ -42,7 +42,7 @@
  */
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "wpe/export.h"
 #endif
 
 #ifdef __cplusplus

--- a/include/wpe/view-backend.h
+++ b/include/wpe/view-backend.h
@@ -38,7 +38,7 @@
  */
 
 #if defined(WPE_COMPILATION)
-#include <wpe/export.h>
+#include "export.h"
 #endif
 
 #ifdef __cplusplus

--- a/include/wpe/wpe-egl.h
+++ b/include/wpe/wpe-egl.h
@@ -34,8 +34,8 @@
 
 #define __WPE_EGL_H_INSIDE__
 
-#include <wpe/wpe.h>
-#include <wpe/renderer-backend-egl.h>
+#include "wpe.h"
+#include "renderer-backend-egl.h"
 
 #undef __WPE_EGL_H_INSIDE__
 

--- a/include/wpe/wpe.h
+++ b/include/wpe/wpe.h
@@ -34,15 +34,15 @@
 
 #define __WPE_H_INSIDE__
 
-#include "wpe/export.h"
-#include "wpe/input.h"
-#include "wpe/keysyms.h"
-#include "wpe/loader.h"
-#include "wpe/pasteboard.h"
-#include "wpe/renderer-host.h"
-#include "wpe/version.h"
-#include "wpe/version-deprecated.h"
-#include "wpe/view-backend.h"
+#include "export.h"
+#include "input.h"
+#include "keysyms.h"
+#include "loader.h"
+#include "pasteboard.h"
+#include "renderer-host.h"
+#include "version.h"
+#include "version-deprecated.h"
+#include "view-backend.h"
 
 #undef __WPE_H_INSIDE__
 

--- a/meson.build
+++ b/meson.build
@@ -88,9 +88,8 @@ libwpe = library('wpe-' + api_version,
 	dependencies: dependencies,
 	version: soversion,
 	soversion: soversion_major,
-	include_directories: 'include',
 	gnu_symbol_visibility: 'hidden',
-	include_directories : [include_directories('include')],
+	include_directories: include_directories('include'),
 )
 
 subdir('include')

--- a/src/input.c
+++ b/src/input.c
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/input.h>
+#include "../include/wpe/input.h"
 
 #include <locale.h>
 #include <stdlib.h>

--- a/src/key-unicode.c
+++ b/src/key-unicode.c
@@ -17,8 +17,8 @@
 
 /* This file is based on gdkkeyuni.c adapted to WPE */
 
-#include <wpe/input.h>
-#include <wpe/keysyms.h>
+#include "../include/wpe/input.h"
+#include "../include/wpe/keysyms.h"
 
 /* Thanks to Markus G. Kuhn <mkuhn@acm.org> for the ksysym<->Unicode
  * mapping functions, from the xterm sources.

--- a/src/loader-private.h
+++ b/src/loader-private.h
@@ -27,7 +27,7 @@
 #ifndef wpe_loader_private_h
 #define wpe_loader_private_h
 
-#include <wpe/loader.h>
+#include "../include/wpe/loader.h"
 
 void*
 wpe_load_object(const char*);

--- a/src/pasteboard-private.h
+++ b/src/pasteboard-private.h
@@ -31,7 +31,7 @@
 extern "C" {
 #endif
 
-#include <wpe/pasteboard.h>
+#include "../include/wpe/pasteboard.h"
 
 struct wpe_pasteboard {
     struct wpe_pasteboard_interface* interface;

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <wpe/renderer-backend-egl.h>
+#include "../include/wpe/renderer-backend-egl.h"
 
 #include "loader-private.h"
 #include "renderer-backend-egl-private.h"

--- a/src/renderer-host-private.h
+++ b/src/renderer-host-private.h
@@ -27,7 +27,7 @@
 #ifndef wpe_renderer_host_private_h
 #define wpe_renderer_host_private_h
 
-#include <wpe/renderer-host.h>
+#include "../include/wpe/renderer-host.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -27,7 +27,7 @@
 #ifndef wpe_view_backend_private_h
 #define wpe_view_backend_private_h
 
-#include <wpe/view-backend.h>
+#include "../include/wpe/view-backend.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Avoid issues with system directories or wpe-fdo include directories being picked first for headers which are known to be local and should always come from the libwpe tree.