### PR TITLE
Meson: Fix building libwpe as a subproject

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -11,7 +11,7 @@ import re
 
 version = {}
 version_re = re.compile(r"^#define\s+WPE_([A-Z]+)_VERSION\s+(\d+)$")
-version_file = path.join(environ["MESON_SOURCE_ROOT"],
+version_file = path.join(environ["MESON_SOURCE_ROOT"], environ["MESON_SUBDIR"],
                          "include", "wpe", "libwpe-version.h")
 
 with open(version_file, "r") as f:


### PR DESCRIPTION
Honor also `MESON_SUBDIR` in the version script. When building as a subproject, `MESON_SOURCE_ROOT` points to the root directory of the top-level project, and `MESON_SUBDIR` will be a non-empty relative path which resolves to the current subdirectory, which is valid also for subprojects.