### PR TITLE
renderer-backend-egl: support explicit deinitialization

### DIFF
--- a/include/wpe/renderer-backend-egl.h
+++ b/include/wpe/renderer-backend-egl.h
@@ -81,9 +81,9 @@ struct wpe_renderer_backend_egl_target_interface {
     void (*resize)(void*, uint32_t, uint32_t);
     void (*frame_will_render)(void*);
     void (*frame_rendered)(void*);
+    void (*deinitialize)(void*);
 
     /*< private >*/
-    void (*_wpe_reserved0)(void);
     void (*_wpe_reserved1)(void);
     void (*_wpe_reserved2)(void);
     void (*_wpe_reserved3)(void);
@@ -161,6 +161,10 @@ wpe_renderer_backend_egl_target_frame_will_render(struct wpe_renderer_backend_eg
 WPE_EXPORT
 void
 wpe_renderer_backend_egl_target_frame_rendered(struct wpe_renderer_backend_egl_target*);
+
+WPE_EXPORT
+void
+wpe_renderer_backend_egl_target_deinitialize(struct wpe_renderer_backend_egl_target*);
 
 WPE_EXPORT
 struct wpe_renderer_backend_egl_offscreen_target*

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -141,7 +141,8 @@ wpe_renderer_backend_egl_target_frame_rendered(struct wpe_renderer_backend_egl_t
 void
 wpe_renderer_backend_egl_target_deinitialize(struct wpe_renderer_backend_egl_target* target)
 {
-    target->base.interface->deinitialize(target->base.interface_data);
+    if (target->base.interface->deinitialize)
+        target->base.interface->deinitialize(target->base.interface_data);
 }
 
 struct wpe_renderer_backend_egl_offscreen_target*

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -138,6 +138,12 @@ wpe_renderer_backend_egl_target_frame_rendered(struct wpe_renderer_backend_egl_t
     target->base.interface->frame_rendered(target->base.interface_data);
 }
 
+void
+wpe_renderer_backend_egl_target_deinitialize(struct wpe_renderer_backend_egl_target* target)
+{
+    target->base.interface->deinitialize(target->base.interface_data);
+}
+
 struct wpe_renderer_backend_egl_offscreen_target*
 wpe_renderer_backend_egl_offscreen_target_create()
 {


### PR DESCRIPTION
Add the wpe_renderer_backend_egl_target_deinitialize() entrypoint, along with
the corresponding wpe_renderer_backend_egl_target_interface member.

This allows for users to explicitly indicate that the target should be
deinitialized before it is destroyed, and for the interface implementors to
properly differentiate between the two events.