### PR TITLE
Explicitly use Meson 0.49 for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Python Packages
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson
+          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson==0.49
       - name: Meson - Configure
         run: |
           mkdir -p _work/meson

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,6 @@ project('libwpe', 'cpp', 'c',
 	default_options: [
 		'b_ndebug=if-release',
 		'c_std=c99',
-		'cpp_eh=none',
 		'cpp_std=c++11',
 	],
 	license: 'BSD-2-Clause',
@@ -35,7 +34,7 @@ add_project_arguments('-DWPE_COMPILATION=1', language: ['c', 'cpp'])
 # Switch to the 'cpp_rtti=false' default option when updating to Meson 0.53 or newer, see
 # https://mesonbuild.com/FAQ.html#how-do-i-disable-exceptions-and-rtti-in-my-c-project
 add_project_arguments(
-	meson.get_compiler('cpp').get_supported_arguments(['-fno-rtti']),
+	meson.get_compiler('cpp').get_supported_arguments(['-fno-rtti', '-fno-exceptions']),
 	language: 'cpp'
 )
 


### PR DESCRIPTION
Our intention is to support Meson 0.49 or newer, so using 0.49 for CI builds prevents accidental usage of features introduced in newer Meson versions. The `cpp_eh` option was added in Meson 0.51, so instead try adding `-fno-exceptions` to the project compiler flags.