### PR TITLE
Add fullscreen API

### DIFF
--- a/include/wpe/view-backend.h
+++ b/include/wpe/view-backend.h
@@ -45,6 +45,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct wpe_view_backend;
@@ -56,6 +57,7 @@ struct wpe_input_touch_event;
 
 struct wpe_view_backend_client;
 struct wpe_view_backend_input_client;
+struct wpe_view_backend_fullscreen_client;
 
 struct wpe_view_backend_interface {
     void* (*create)(void*, struct wpe_view_backend*);
@@ -96,6 +98,53 @@ wpe_view_backend_set_backend_client(struct wpe_view_backend*, const struct wpe_v
 WPE_EXPORT
 void
 wpe_view_backend_set_input_client(struct wpe_view_backend*, const struct wpe_view_backend_input_client*, void*);
+
+/**
+ * wpe_view_backend_set_fullscreen_client:
+ * @view_backend: (transfer none): The view backend to obtains events from.
+ * @client: (transfer none): Client with callbacks for the events.
+ * @userdata: (transfer none): User data passed to client callbacks.
+ * 
+ * Configure a @client with callbacks invoked for DOM fullscreen requests.
+ * 
+ * This function must be only used once for a given @view_backend, the client
+ * cannot be changed once it has been set.
+ *
+ * Since: 1.12
+ */
+WPE_EXPORT
+void
+wpe_view_backend_set_fullscreen_client(struct wpe_view_backend*, const struct wpe_view_backend_fullscreen_client*, void*);
+
+/**
+ * wpe_view_backend_fullscreen_handler:
+ * @userdata: (transfer none): User data passed to the embedder.
+ * @enable: (transfer none): User data passed to the embedder.
+ * 
+ * Type of functions used by an embedder to implement fullscreening web views.
+ *
+ * Returns: a boolean indicating whether the operation was completed.
+ * 
+ * Since: 1.12
+ */
+typedef bool (*wpe_view_backend_fullscreen_handler)(void *userdata, bool enable);
+
+/**
+ * wpe_view_backend_set_fullscreen_handler:
+ * @view_backend: (transfer none): The view backend to obtains events from.
+ * @handler: (transfer none): Function used by an embedder to implement fullscreening web views.
+ * @userdata: (transfer none): User data passed to the handler function.
+ * 
+ * Handler function set by an embedder to implement fullscreening web views.
+ * 
+ * This function must be only used once for a given @view_backend, the handler
+ * cannot be changed once it has been set.
+ *
+ * Since: 1.12
+ */
+WPE_EXPORT
+void
+wpe_view_backend_set_fullscreen_handler(struct wpe_view_backend*, wpe_view_backend_fullscreen_handler handler, void* userdata);
 
 WPE_EXPORT
 void
@@ -178,6 +227,97 @@ wpe_view_backend_dispatch_axis_event(struct wpe_view_backend*, struct wpe_input_
 WPE_EXPORT
 void
 wpe_view_backend_dispatch_touch_event(struct wpe_view_backend*, struct wpe_input_touch_event*);
+
+/**
+ * wpe_view_backend_fullscreen_client:
+ * @did_enter_fullscreen: Invoked after fullscreen has been successfully entered.
+ * @did_exit_fullscreen: Invoked after fullscreen has been exited.
+ * @request_enter_fullscreen: Invoked after user has requested to enter fullscreen.
+ * @request_exit_fullscreen: Invoked after user has requested to exit fullscreen.
+ *
+ * A view backend's fullscreen client provides a series of callback functions
+ * which are invoked at different stages when a web view becomes fullscreened
+ * and back.
+ *
+ * Since: 1.12
+ */
+struct wpe_view_backend_fullscreen_client {
+    void (*did_enter_fullscreen)(void*);
+    void (*did_exit_fullscreen)(void*);
+    void (*request_enter_fullscreen)(void*);
+    void (*request_exit_fullscreen)(void*);
+
+    /*< private >*/
+    void (*_wpe_reserved0)(void);
+    void (*_wpe_reserved1)(void);
+    void (*_wpe_reserved2)(void);
+    void (*_wpe_reserved3)(void);
+};
+
+/**
+ * wpe_view_backend_platform_set_fullscreen:
+ * @view_backend: (transfer none): The view backend which fullscreen state will be changed.
+ * @fullscreen: (transfer none): True if fullscreen.
+ * 
+ * Returns: a boolean indicating whether the operation was completed.
+ * 
+ * DOM content calls this function to request the platform to enter/exit fullscreen.
+ * The platform will attempt to change it's window fullscreen state.
+ *
+ * Since: 1.12
+ */
+WPE_EXPORT
+bool
+wpe_view_backend_platform_set_fullscreen(struct wpe_view_backend*, bool);
+
+/**
+ * wpe_view_backend_dispatch_did_enter_fullscreen:
+ * @view_backend: (transfer none): The view backend that triggered the event.
+ * 
+ * Dispatchs the event that indicates fullscreen has been successfully entered.
+ *
+ * Since: 1.12
+ */
+WPE_EXPORT
+void
+wpe_view_backend_dispatch_did_enter_fullscreen(struct wpe_view_backend*);
+
+/**
+ * wpe_view_backend_dispatch_did_exit_fullscreen:
+ * @view_backend: (transfer none): The view backend that triggered the event.
+ * 
+ * Dispatchs the event that indicated fullscreen has been successfully entered.
+ *
+ * Since: 1.12
+ */
+WPE_EXPORT
+void
+wpe_view_backend_dispatch_did_exit_fullscreen(struct wpe_view_backend*);
+
+/**
+ * wpe_view_backend_dispatch_request_enter_fullscreen:
+ * @view_backend: (transfer none): The view backend that triggered the event.
+ * 
+ * Dispatchs the event that indicates user wants to enter DOM fullscreen state.
+ *
+ * Since: 1.12
+ */
+WPE_EXPORT
+void
+wpe_view_backend_dispatch_request_enter_fullscreen(struct wpe_view_backend*);
+
+/**
+ * wpe_view_backend_dispatch_request_exit_fullscreen:
+ * @view_backend: (transfer none): The view backend that triggered the event.
+ * 
+ * Dispatchs the event that indicates user wants to exit DOM fullscreen state.
+ *
+ * Since: 1.12
+ */
+WPE_EXPORT
+void
+wpe_view_backend_dispatch_request_exit_fullscreen(struct wpe_view_backend*);
+
 
 #ifdef __cplusplus
 }

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -42,6 +42,12 @@ struct wpe_view_backend {
     const struct wpe_view_backend_input_client* input_client;
     void* input_client_data;
 
+    const struct wpe_view_backend_fullscreen_client* fullscreen_client;
+    void* fullscreen_client_data;
+
+    wpe_view_backend_fullscreen_handler fullscreen_handler;
+    void* fullscreen_handler_data;
+
     uint32_t activity_state;
 };
 

--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -27,6 +27,7 @@
 #include "view-backend-private.h"
 
 #include "loader-private.h"
+#include <assert.h>
 #include <stdlib.h>
 
 
@@ -65,6 +66,9 @@ wpe_view_backend_destroy(struct wpe_view_backend* backend)
     backend->input_client = 0;
     backend->input_client_data = 0;
 
+    backend->fullscreen_client = NULL;
+    backend->fullscreen_client_data = NULL;
+
     backend->activity_state = 0;
 
     free(backend);
@@ -91,6 +95,15 @@ wpe_view_backend_set_input_client(struct wpe_view_backend* backend, const struct
 {
     backend->input_client = client;
     backend->input_client_data = client_data;
+}
+
+void
+wpe_view_backend_set_fullscreen_client(struct wpe_view_backend* backend, const struct wpe_view_backend_fullscreen_client* client, void* client_data)
+{
+    assert(!backend->fullscreen_client);
+
+    backend->fullscreen_client = client;
+    backend->fullscreen_client_data = client_data;
 }
 
 void
@@ -186,4 +199,49 @@ wpe_view_backend_dispatch_touch_event(struct wpe_view_backend* backend, struct w
 {
     if (backend->input_client)
         backend->input_client->handle_touch_event(backend->input_client_data, event);
+}
+
+void
+wpe_view_backend_set_fullscreen_handler(struct wpe_view_backend* backend, wpe_view_backend_fullscreen_handler handler, void* userdata)
+{
+    assert(!backend->fullscreen_handler);
+
+    backend->fullscreen_handler = handler;
+    backend->fullscreen_handler_data = userdata;
+}
+
+bool
+wpe_view_backend_platform_set_fullscreen(struct wpe_view_backend* backend, bool fullscreen)
+{
+    if (backend->fullscreen_handler)
+        return backend->fullscreen_handler(backend->fullscreen_handler_data, fullscreen);
+    return false;
+}
+
+void
+wpe_view_backend_dispatch_did_enter_fullscreen(struct wpe_view_backend* backend)
+{
+    if (backend->fullscreen_client)
+        backend->fullscreen_client->did_enter_fullscreen(backend->fullscreen_client_data);
+}
+
+void
+wpe_view_backend_dispatch_did_exit_fullscreen(struct wpe_view_backend* backend)
+{
+    if (backend->fullscreen_client)
+        backend->fullscreen_client->did_exit_fullscreen(backend->fullscreen_client_data);
+}
+
+void
+wpe_view_backend_dispatch_request_enter_fullscreen(struct wpe_view_backend* backend)
+{
+    if (backend->fullscreen_client)
+        backend->fullscreen_client->request_enter_fullscreen(backend->fullscreen_client_data);
+}
+
+void
+wpe_view_backend_dispatch_request_exit_fullscreen(struct wpe_view_backend* backend)
+{
+    if (backend->fullscreen_client)
+        backend->fullscreen_client->request_exit_fullscreen(backend->fullscreen_client_data);
 }


### PR DESCRIPTION
- Receive DOM fullscreen state via wpe_view_backend_set_fullscreen
- Dispatch exit/enter fullscreem from libwpe to the client (e.g. WPEView in Webkit)

----

Corresponding WPE WebKit patch: https://bugs.webkit.org/show_bug.cgi?id=227951