### PR TITLE
CMake: Use current source and binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 cmake_policy(VERSION 3.0)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(VersioningUtils)
 
-READ_VERSION_HEADER("" "WPE_[A-Z]+_VERSION" "${CMAKE_SOURCE_DIR}/include/wpe/libwpe-version.h")
+READ_VERSION_HEADER("" "WPE_[A-Z]+_VERSION" "${CMAKE_CURRENT_SOURCE_DIR}/include/wpe/libwpe-version.h")
 SET_PROJECT_VERSION(${WPE_MAJOR_VERSION} ${WPE_MINOR_VERSION} ${WPE_MICRO_VERSION})
 set(WPE_API_VERSION "1.0")
 
@@ -138,12 +138,12 @@ IF(BUILD_DOCS)
       ${HOTDOC} run
       --project-name=libwpe
       --project-version=1.0
-      --include-paths="${CMAKE_SOURCE_DIR}/docs"
-      --sitemap=${CMAKE_SOURCE_DIR}/docs/sitemap.txt
+      --include-paths="${CMAKE_CURRENT_SOURCE_DIR}/docs"
+      --sitemap=${CMAKE_CURRENT_SOURCE_DIR}/docs/sitemap.txt
       --output=${CMAKE_CURRENT_BINARY_DIR}/Documentation/
-      --c-sources "${CMAKE_SOURCE_DIR}/include/wpe/*.h"
+      --c-sources "${CMAKE_CURRENT_SOURCE_DIR}/include/wpe/*.h"
       --extra-c-flags=-DWPE_COMPILATION=1
-      --c-include-directories ${CMAKE_SOURCE_DIR}/include
+      --c-include-directories ${CMAKE_CURRENT_SOURCE_DIR}/include
       --c-smart-index
     )
   ELSE()

--- a/cmake/DistTargets.cmake
+++ b/cmake/DistTargets.cmake
@@ -18,12 +18,12 @@ set(ARCHIVE_FULL_NAME ${ARCHIVE_BASE_NAME}.tar.xz)
 
 add_custom_target(dist
 	COMMAND ${CMAKE_COMMAND} -E echo "Creating '${ARCHIVE_FULL_NAME}'..."
-	COMMAND git archive --prefix=${ARCHIVE_BASE_NAME}/ HEAD | xz -z > ${CMAKE_BINARY_DIR}/${ARCHIVE_FULL_NAME}
-	COMMAND ${CMAKE_COMMAND} -E echo "Distribution tarball '${ARCHIVE_FULL_NAME}' created at ${CMAKE_BINARY_DIR}"
-	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+	COMMAND git archive --prefix=${ARCHIVE_BASE_NAME}/ HEAD | xz -z > ${CMAKE_CURRENT_BINARY_DIR}/${ARCHIVE_FULL_NAME}
+	COMMAND ${CMAKE_COMMAND} -E echo "Distribution tarball '${ARCHIVE_FULL_NAME}' created at ${CMAKE_CURRENT_BINARY_DIR}"
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-set(disttest_extract_dir "${CMAKE_BINARY_DIR}/${ARCHIVE_BASE_NAME}")
+set(disttest_extract_dir "${CMAKE_CURRENT_BINARY_DIR}/${ARCHIVE_BASE_NAME}")
 set(disttest_build_dir "${disttest_extract_dir}/_build")
 set(disttest_install_dir "${disttest_extract_dir}/_install")
 
@@ -32,7 +32,7 @@ add_custom_command(OUTPUT ${disttest_build_dir}/Makefile
 	COMMAND ${CMAKE_COMMAND} -E remove_directory ${disttest_extract_dir}
 
 	# extract the tarball
-	COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR} tar -xf ${ARCHIVE_FULL_NAME}
+	COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} tar -xf ${ARCHIVE_FULL_NAME}
 
 	# create a _build sub-directory
 	COMMAND ${CMAKE_COMMAND} -E make_directory "${disttest_build_dir}"


### PR DESCRIPTION
If libpwe is built within a larger CMake project, using the FetchContent module, its use of `CMAKE_SOURCE_DIR` instead of `CMAKE_CURRENT_SOURCE_DIR` makes it so things like modules aren't loaded properly. Move all uses of `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` to their `CURRENT` variant.