### PR TITLE
Allow libwpe to be built statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ calculate_library_versions_from_libtool_triple(LIBWPE 6 0 5)
 
 project(libwpe VERSION "${PROJECT_VERSION}")
 
+set(BUILD_SHARED_LIBS
+    ON
+    CACHE BOOL "Build libwpe as a shared library"
+)
 set(WPE_BACKEND
     ""
     CACHE STRING "Name of the backend library to load, instead of libWPEBackend-default.so"
@@ -71,10 +75,9 @@ set(WPE_PUBLIC_HEADERS
 )
 
 add_library(
-    wpe SHARED
+    wpe
     src/input-xkb.c
     src/key-unicode.c
-    src/loader.c
     src/pasteboard.c
     src/pasteboard-generic.cpp
     src/pasteboard-noop.cpp
@@ -83,6 +86,23 @@ add_library(
     src/version.c
     src/view-backend.c
 )
+
+if (BUILD_SHARED_LIBS)
+    target_sources(wpe PRIVATE src/loader.c)
+
+    set_target_properties(
+        wpe
+        PROPERTIES
+            C_VISIBILITY_PRESET hidden
+            CXX_VISIBILITY_PRESET hidden
+            OUTPUT_NAME wpe-${WPE_API_VERSION}
+            VERSION ${LIBWPE_VERSION}
+            SOVERSION ${LIBWPE_VERSION_MAJOR}
+    )
+else ()
+    target_sources(wpe PRIVATE src/loader-static.c)
+endif ()
+
 target_include_directories(
     wpe PRIVATE "include" "src" $<TARGET_PROPERTY:GL::egl,INTERFACE_INCLUDE_DIRECTORIES>
 )
@@ -104,16 +124,6 @@ if (WPE_ENABLE_XKB)
     target_link_libraries(wpe PRIVATE XkbCommon::libxkbcommon)
     set(WPE_PC_REQUIRES xkbcommon)
 endif ()
-
-set_target_properties(
-    wpe
-    PROPERTIES
-        C_VISIBILITY_PRESET hidden
-        CXX_VISIBILITY_PRESET hidden
-        OUTPUT_NAME wpe-${WPE_API_VERSION}
-        VERSION ${LIBWPE_VERSION}
-        SOVERSION ${LIBWPE_VERSION_MAJOR}
-)
 
 install(
     TARGETS wpe

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,7 @@ if not cc.has_function('dlopen')
 endif
 
 libwpe = library('wpe-' + api_version,
+	get_option(default_library) == "shared" ? 'src/loader.c' : 'src/loader-static.c'
 	'src/input-xkb.c',
 	'src/key-unicode.c',
 	'src/loader.c',

--- a/src/loader-static.c
+++ b/src/loader-static.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "loader-private.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+extern struct wpe_loader_interface* _wpe_loader_interface;
+
+bool
+wpe_loader_init(const char* impl_library_name)
+{
+    return true;
+}
+
+const char*
+wpe_loader_get_loaded_implementation_library_name(void)
+{
+#ifdef WPE_BACKEND
+    return WPE_BACKEND;
+#else
+    return NULL;
+#endif
+}
+
+void*
+wpe_load_object(const char* object_name)
+{
+    if (_wpe_loader_interface) {
+        if (!_wpe_loader_interface->load_object) {
+            fprintf(stderr, "wpe_load_object: failed to load object with name '%s': backend doesn't implement load_object vfunc\n", object_name);
+            abort();
+        }
+        return _wpe_loader_interface->load_object(object_name);
+    }
+
+    return NULL;
+}


### PR DESCRIPTION
In the case where there will only ever be one WPE backend implemented for a platform the dynamic loading capabilities aren't needed. In this case allow the library to built statically.