### PR TITLE
Allow disabling of xkb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ project(libwpe VERSION "${PROJECT_VERSION}")
 
 set(WPE_BACKEND "" CACHE STRING
     "Name of the backend library to load, instead of libWPEBackend-default.so")
+set(WPE_DISABLE_XKB_INPUT OFF CACHE STRING "Disable use of libxkbcommon for keyboard input")
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
@@ -46,7 +47,6 @@ include(DistTargets)
 include(GNUInstallDirs)
 
 find_package(EGL REQUIRED)
-find_package(Libxkbcommon REQUIRED)
 
 set(WPE_PUBLIC_HEADERS
   include/wpe/libwpe-version.h
@@ -65,7 +65,7 @@ set(WPE_PUBLIC_HEADERS
 )
 
 add_library(wpe SHARED
-    src/input.c
+    src/input-xkb.c
     src/key-unicode.c
     src/loader.c
     src/pasteboard.c
@@ -88,10 +88,18 @@ target_compile_definitions(wpe PRIVATE
 if (WPE_BACKEND)
     target_compile_definitions(wpe PRIVATE WPE_BACKEND=\"${WPE_BACKEND}\")
 endif()
+if (WPE_DISABLE_XKB_INPUT)
+    target_compile_definitions(wpe PUBLIC WPE_DISABLE_XKB_INPUT=1)
+endif()
 target_compile_options(wpe PRIVATE
     $<TARGET_PROPERTY:GL::egl,INTERFACE_COMPILE_OPTIONS>
 )
-target_link_libraries(wpe PRIVATE XkbCommon::libxkbcommon ${CMAKE_DL_LIBS})
+
+target_link_libraries(wpe PRIVATE ${CMAKE_DL_LIBS})
+if (NOT WPE_DISABLE_XKB_INPUT)
+    find_package(Libxkbcommon REQUIRED)
+    target_link_libraries(wpe PRIVATE XkbCommon::libxkbcommon)
+endif()
 
 set_target_properties(wpe PROPERTIES
   C_VISIBILITY_PRESET hidden

--- a/include/wpe/input-xkb.h
+++ b/include/wpe/input-xkb.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2015, 2016 Igalia S.L.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !defined(__WPE_H_INSIDE__) && !defined(WPE_COMPILATION)
+#error "Only <wpe/wpe.h> can be included directly."
+#endif
+
+#ifndef wpe_input_xkb_h
+#define wpe_input_xkb_h
+
+/**
+ * SECTION:input
+ * @short_description: Input Handling
+ * @title: Input
+ */
+
+#if !(defined(WPE_DISABLE_XKB_INPUT) && WPE_DISABLE_XKB_INPUT)
+
+#if defined(WPE_COMPILATION)
+#include "export.h"
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbcommon-compose.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct wpe_input_xkb_context;
+
+struct wpe_input_xkb_keymap_entry {
+    uint32_t hardware_key_code;
+    int32_t layout;
+    int32_t level;
+};
+
+WPE_EXPORT
+struct wpe_input_xkb_context*
+wpe_input_xkb_context_get_default();
+
+WPE_EXPORT
+struct xkb_context*
+wpe_input_xkb_context_get_context(struct wpe_input_xkb_context*);
+
+WPE_EXPORT
+struct xkb_keymap*
+wpe_input_xkb_context_get_keymap(struct wpe_input_xkb_context*);
+
+WPE_EXPORT
+void
+wpe_input_xkb_context_set_keymap(struct wpe_input_xkb_context*, struct xkb_keymap*);
+
+WPE_EXPORT
+struct xkb_state*
+wpe_input_xkb_context_get_state(struct wpe_input_xkb_context*);
+
+WPE_EXPORT
+struct xkb_compose_table*
+wpe_input_xkb_context_get_compose_table(struct wpe_input_xkb_context*);
+
+WPE_EXPORT
+void
+wpe_input_xkb_context_set_compose_table(struct wpe_input_xkb_context*, struct xkb_compose_table*);
+
+WPE_EXPORT
+struct xkb_compose_state*
+wpe_input_xkb_context_get_compose_state(struct wpe_input_xkb_context*);
+
+WPE_EXPORT
+uint32_t
+wpe_input_xkb_context_get_modifiers(struct wpe_input_xkb_context*, uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group);
+
+WPE_EXPORT
+uint32_t
+wpe_input_xkb_context_get_key_code(struct wpe_input_xkb_context*, uint32_t hardware_key_code, bool pressed);
+
+WPE_EXPORT
+void
+wpe_input_xkb_context_get_entries_for_key_code(struct wpe_input_xkb_context*, uint32_t key_code, struct wpe_input_xkb_keymap_entry**, uint32_t* n_entries);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* defined(WPE_DISABLE_XKB_INPUT) && WPE_DISABLE_XKB_INPUT */
+
+#endif /* wpe_input_xkb_h */

--- a/include/wpe/input.h
+++ b/include/wpe/input.h
@@ -43,8 +43,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <xkbcommon/xkbcommon.h>
-#include <xkbcommon/xkbcommon-compose.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -139,58 +137,6 @@ struct wpe_input_touch_event {
     uint32_t modifiers;
 };
 
-
-struct wpe_input_xkb_context;
-
-struct wpe_input_xkb_keymap_entry {
-    uint32_t hardware_key_code;
-    int32_t layout;
-    int32_t level;
-};
-
-WPE_EXPORT
-struct wpe_input_xkb_context*
-wpe_input_xkb_context_get_default();
-
-WPE_EXPORT
-struct xkb_context*
-wpe_input_xkb_context_get_context(struct wpe_input_xkb_context*);
-
-WPE_EXPORT
-struct xkb_keymap*
-wpe_input_xkb_context_get_keymap(struct wpe_input_xkb_context*);
-
-WPE_EXPORT
-void
-wpe_input_xkb_context_set_keymap(struct wpe_input_xkb_context*, struct xkb_keymap*);
-
-WPE_EXPORT
-struct xkb_state*
-wpe_input_xkb_context_get_state(struct wpe_input_xkb_context*);
-
-WPE_EXPORT
-struct xkb_compose_table*
-wpe_input_xkb_context_get_compose_table(struct wpe_input_xkb_context*);
-
-WPE_EXPORT
-void
-wpe_input_xkb_context_set_compose_table(struct wpe_input_xkb_context*, struct xkb_compose_table*);
-
-WPE_EXPORT
-struct xkb_compose_state*
-wpe_input_xkb_context_get_compose_state(struct wpe_input_xkb_context*);
-
-WPE_EXPORT
-uint32_t
-wpe_input_xkb_context_get_modifiers(struct wpe_input_xkb_context*, uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group);
-
-WPE_EXPORT
-uint32_t
-wpe_input_xkb_context_get_key_code(struct wpe_input_xkb_context*, uint32_t hardware_key_code, bool pressed);
-
-WPE_EXPORT
-void
-wpe_input_xkb_context_get_entries_for_key_code(struct wpe_input_xkb_context*, uint32_t key_code, struct wpe_input_xkb_keymap_entry**, uint32_t* n_entries);
 
 WPE_EXPORT
 uint32_t

--- a/include/wpe/meson.build
+++ b/include/wpe/meson.build
@@ -1,6 +1,7 @@
 api_headers = [
 	'export.h',
 	'input.h',
+	'input-xkb.h',
 	'keysyms.h',
 	'libwpe-version.h',
 	'loader.h',

--- a/include/wpe/wpe.h
+++ b/include/wpe/wpe.h
@@ -36,6 +36,7 @@
 
 #include "export.h"
 #include "input.h"
+#include "input-xkb.h"
 #include "keysyms.h"
 #include "loader.h"
 #include "pasteboard.h"

--- a/meson.build
+++ b/meson.build
@@ -51,12 +51,16 @@ dependencies = []
 #
 can_allow_fallback = meson.version().version_compare('>=0.55.0')
 
-if can_allow_fallback
-	dependencies += dependency('xkbcommon',
-		fallback: ['libxkbcommon', 'libxkbcommon_dep'],
-	)
+if get_option('disable-xkb-input')
+	add_project_arguments('-DWPE_DISABLE_XKB_INPUT=1', language: ['c', 'cpp'])
 else
-	dependencies += dependency('xkbcommon')
+	if can_allow_fallback
+		dependencies += dependency('xkbcommon',
+			fallback: ['libxkbcommon', 'libxkbcommon_dep'],
+		)
+	else
+		dependencies += dependency('xkbcommon')
+	endif
 endif
 
 cc = meson.get_compiler('c')
@@ -83,7 +87,7 @@ if not cc.has_function('dlopen')
 endif
 
 libwpe = library('wpe-' + api_version,
-	'src/input.c',
+	'src/input-xkb.c',
 	'src/key-unicode.c',
 	'src/loader.c',
 	'src/pasteboard.c',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,11 @@ option('default-backend',
 	value: '',
 	description: 'Name of the backend library to load, instead of libWPEBackend-default.so'
 )
+option('disable-xkb-input',
+	type: 'boolean',
+	value: false,
+	description: 'Disable use of libxkbcommon for keyboard input'
+)
 option('build-docs',
 	type: 'boolean',
 	value: false,

--- a/src/input-xkb.c
+++ b/src/input-xkb.c
@@ -24,6 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if !(defined(WPE_DISABLE_XKB_INPUT) && WPE_DISABLE_XKB_INPUT)
+
+#include "../include/wpe/input-xkb.h"
 #include "../include/wpe/input.h"
 
 #include <locale.h>
@@ -244,3 +247,5 @@ wpe_input_xkb_context_get_entries_for_key_code(struct wpe_input_xkb_context* xkb
     *entries = array;
     *n_entries = array_size;
 }
+
+#endif /* !(defined(WPE_DISABLE_XKB_INPUT) && WPE_DISABLE_XKB_INPUT) */


### PR DESCRIPTION
The `xkbcommon` library is geared towards platforms using the XKB specification so it should be disableable. Add a WPE_DISABLE_XKB_INPUT option to prevent xkb code from being compiled. By default this option is off so this is not a breaking change.

The contents of `wpe/input.h` that require `xkbcommon` are split into `wpe/input-xkb.h` The `src/input.c` was renamed to `src/input-xkb.c` to indicate the file is specific to xkb being enabled.