### PR TITLE
CI: Update to Python 3.6, bump actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
             libegl1-mesa-dev libxml2-dev libxslt1-dev libyaml-dev llvm-dev \
             libclang-dev libglib2.0-dev ninja-build
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.5
+          python-version: 3.6
       - name: Python Package Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
@@ -102,20 +102,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
       - name: Setup MSVC
         uses: seanmiddleditch/gha-setup-vsdevenv@master
-      - name: Install Bison
+      - name: Install Tools
         run: |
-          choco install winflexbison3 -y --no-progress --stop-on-first-failure
-      - name: Build
-        uses: BSFishy/meson-build@v1.0.3
-        with:
-          action: build
-          meson-version: 0.56.0
-          setup-options: >-
-            -Dbuild-docs=false
-            -Dlibxkbcommon:enable-docs=false
-            -Dlibxkbcommon:enable-wayland=false
-            -Dlibxkbcommon:enable-x11=false
-            -Dlibxkbcommon:enable-xkbregistry=false
+          choco install winflexbison3 ninja -y --no-progress --stop-on-first-failure
+      - name: Install Python Packages
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install meson==0.56
+      - name: Meson - Configure
+        run: >+
+          meson _build
+          -Dbuild-docs=false
+          -Dlibxkbcommon:enable-docs=false
+          -Dlibxkbcommon:enable-wayland=false
+          -Dlibxkbcommon:enable-x11=false
+          -Dlibxkbcommon:enable-xkbregistry=false
+      - name: Meson - Build
+        run: |
+          ninja -C _build

--- a/subprojects/libxkbcommon.wrap
+++ b/subprojects/libxkbcommon.wrap
@@ -1,3 +1,5 @@
-[wrap-git]
-revision = 9d87f8491595e0a6bd2d8b3eff266712c9b5c63d
-url = https://github.com/xkbcommon/libxkbcommon
+[wrap-file]
+directory = libxkbcommon-1.4.0
+source_url = https://xkbcommon.org/download/libxkbcommon-1.4.0.tar.xz
+source_filename = libxkbcommon-1.4.0.tar.xz
+source_hash = 106cec5263f9100a7e79b5f7220f889bc78e7d7ffc55d2b6fdb1efefb8024031


### PR DESCRIPTION
Python 3.5 is no longer supported by GitHub Actions. While at it, bump the `setup-python` and `cache` actions to v2, and simplify the Windows build to use less third party actions.
