### PR TITLE
Clarify CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,15 @@
 ---
 
-name: CI
+name: CI Build
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+    - 'libwpe-*'
+  pull_request:
+    branches:
+    - master
 
 jobs:
   linux:
@@ -125,4 +132,3 @@ jobs:
       - name: Meson - Build
         run: |
           ninja -C _build
-

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,8 +1,11 @@
 ---
 
-name: CI PR
+name: CI Source Formatting
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+    - master
 
 jobs:
   format-cmake:


### PR DESCRIPTION
Rename ci.yml to build.yml since it is explicitly building the project and documentation. Also make this workflow run on PR because whether the build was successful was not being beamed to a status check.

Rename pr.yml to format.yml since it is explicitly ensuring that the source code is properly formatted.