### PR TITLE
build: Fix warning messages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Python Packages
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson==0.49
+          HOTDOC_BUILD_C_EXTENSION=enabled pip install hotdoc meson==0.55
       - name: Meson - Configure
         run: |
           mkdir -p _work/meson

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,12 @@
 project('libwpe', 'cpp', 'c',
-	meson_version: '>=0.49',
+	meson_version: '>=0.55',
 	default_options: [
 		'b_ndebug=if-release',
 		'c_std=c99',
 		'cpp_std=c++11',
 	],
 	license: 'BSD-2-Clause',
-	version: run_command(join_paths('scripts', 'version.py')).stdout().strip(),
+	version: run_command(join_paths('scripts', 'version.py'), check: true).stdout().strip(),
 )
 
 # This refers to the API level provided. This is modified only with major,
@@ -46,21 +46,11 @@ endif
 dependencies = []
 pkg_cflags = []
 
-#
-# Meson 0.55.0 is needed for "patch_directory" in .wrap files
-# and for the "allow_fallback" keyword in dependency() calls.
-#
-can_allow_fallback = meson.version().version_compare('>=0.55.0')
-
 if get_option('enable-xkb')
 	pkg_cflags += ['-DWPE_ENABLE_XKB=1']
-	if can_allow_fallback
-		dependencies += dependency('xkbcommon',
-			fallback: ['libxkbcommon', 'libxkbcommon_dep'],
-		)
-	else
-		dependencies += dependency('xkbcommon')
-	endif
+	dependencies += dependency('xkbcommon',
+		fallback: ['libxkbcommon', 'libxkbcommon_dep'],
+	)
 endif
 
 cc = meson.get_compiler('c')
@@ -77,9 +67,9 @@ elif target_machine.system() != 'windows'
 endif
 
 if not cc.has_function('dlopen')
-	dl_dep = cc.find_library('dl', required: not can_allow_fallback)
-	if can_allow_fallback and not dl_dep.found()
-		dl_dep = dependency('dl', required: true,
+	dl_dep = cc.find_library('dl', required: false)
+	if not dl_dep.found()
+		dl_dep = dependency('dl',
 			allow_fallback: target_machine.system() == 'windows',
 		)
 	endif


### PR DESCRIPTION
These warnings appeared while running meson:

WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
WARNING: Project targeting '>=0.49' but tried to use feature introduced in '0.55.0': Wrap files with patch_directory.

This patch addresses both issues.