### PR TITLE
Add target refresh rate to view-backend

### DIFF
--- a/include/wpe/view-backend.h
+++ b/include/wpe/view-backend.h
@@ -166,9 +166,7 @@ struct wpe_view_backend_client {
     void (*activity_state_changed)(void*, uint32_t);
     void* (*get_accessible)(void*);
     void (*set_device_scale_factor)(void*, float);
-
-    /*< private >*/
-    void (*_wpe_reserved0)(void);
+    void (*target_refresh_rate_changed)(void*, uint32_t);
 };
 
 WPE_EXPORT
@@ -198,6 +196,12 @@ wpe_view_backend_dispatch_get_accessible(struct wpe_view_backend* backend);
 WPE_EXPORT
 void
 wpe_view_backend_dispatch_set_device_scale_factor(struct wpe_view_backend*, float);
+
+WPE_EXPORT
+uint32_t wpe_view_backend_get_target_refresh_rate(struct wpe_view_backend*);
+
+WPE_EXPORT
+void wpe_view_backend_set_target_refresh_rate(struct wpe_view_backend*, uint32_t);
 
 struct wpe_view_backend_input_client {
     void (*handle_keyboard_event)(void*, struct wpe_input_keyboard_event*);

--- a/src/view-backend-private.h
+++ b/src/view-backend-private.h
@@ -49,6 +49,7 @@ struct wpe_view_backend {
     void* fullscreen_handler_data;
 
     uint32_t activity_state;
+    uint32_t refresh_rate;
 };
 
 #ifdef __cplusplus

--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -70,6 +70,7 @@ wpe_view_backend_destroy(struct wpe_view_backend* backend)
     backend->fullscreen_client_data = NULL;
 
     backend->activity_state = 0;
+    backend->refresh_rate = 0;
 
     free(backend);
 }
@@ -171,6 +172,22 @@ wpe_view_backend_dispatch_set_device_scale_factor(struct wpe_view_backend* backe
 {
     if (backend->backend_client && backend->backend_client->set_device_scale_factor)
         backend->backend_client->set_device_scale_factor(backend->backend_client_data, scale);
+}
+
+void
+wpe_view_backend_set_target_refresh_rate(struct wpe_view_backend* backend, uint32_t rate)
+{
+    if (backend->refresh_rate != rate) {
+        backend->refresh_rate = rate;
+        if (backend->backend_client && backend->backend_client->target_refresh_rate_changed)
+            backend->backend_client->target_refresh_rate_changed(backend->backend_client_data, backend->refresh_rate);
+    }
+}
+
+uint32_t
+wpe_view_backend_get_target_refresh_rate(struct wpe_view_backend* backend)
+{
+    return backend->refresh_rate;
 }
 
 void


### PR DESCRIPTION
Add accessors and notification callbacks for the target refresh rate of a
view backend. This allows a client to be notified when the target refresh
rate of a screen changes.