### PR TITLE
Avoid using xkbcommon headers in libwpe headers

### DIFF
--- a/include/wpe/input-xkb.h
+++ b/include/wpe/input-xkb.h
@@ -45,12 +45,16 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <xkbcommon/xkbcommon.h>
-#include <xkbcommon/xkbcommon-compose.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+struct xkb_compose_state;
+struct xkb_compose_table;
+struct xkb_context;
+struct xkb_keymap;
+struct xkb_state;
 
 struct wpe_input_xkb_context;
 

--- a/wpe.pc.in
+++ b/wpe.pc.in
@@ -6,6 +6,6 @@ libdir=${exec_prefix}/lib
 Name: wpe-@WPE_API_VERSION@
 Description: The wpe library
 Version: @PROJECT_VERSION@
-Requires: @WPE_PC_REQUIRES@
+Requires.private: @WPE_PC_REQUIRES@
 Cflags: -I${includedir}/wpe-@WPE_API_VERSION@ @WPE_PC_CFLAGS@
 Libs: -L${libdir} -lwpe-@WPE_API_VERSION@


### PR DESCRIPTION
Forward-declare a few opaque types in `input-xkb.h` in order to avoid needing to list `xkbcommon` as a public dependency in the generated pkg-config module files. This allows programs which do not use libwpe's xkbcommon functions to skip linking against libxkbcommon, even if libwpe has been built with libxkbcommon support.

Fixes #107