### PR TITLE
fix: use generic pasteboard by default

### DIFF
--- a/src/pasteboard.c
+++ b/src/pasteboard.c
@@ -70,7 +70,7 @@ wpe_pasteboard_get_singleton()
         s_pasteboard = calloc(1, sizeof(struct wpe_pasteboard));
         s_pasteboard->interface = wpe_load_object("_wpe_pasteboard_interface");
         if (!s_pasteboard->interface)
-            s_pasteboard->interface = &noop_pasteboard_interface;
+            s_pasteboard->interface = &generic_pasteboard_interface;
         s_pasteboard->interface_data = s_pasteboard->interface->initialize(s_pasteboard);
     }
 


### PR DESCRIPTION
It was changed from `generic` to `noop` in https://github.com/WebPlatformForEmbedded/libwpe/commit/936e64c6d7a48a25b0f0d8bd85f56b350f65a1a4 which breaks basic keyboard functionality in wpewebkit.