### PR TITLE
Fix memory allocation issues in pasteboard get_types()

### DIFF
--- a/src/pasteboard-generic.cpp
+++ b/src/pasteboard-generic.cpp
@@ -51,9 +51,9 @@ struct wpe_pasteboard_interface generic_pasteboard_interface = {
         if (!length)
             return;
 
-        out_vector->strings = static_cast<struct wpe_pasteboard_string*>(calloc(1, sizeof(struct wpe_pasteboard_string) * length));
+        out_vector->strings = static_cast<struct wpe_pasteboard_string*>(calloc(length, sizeof(struct wpe_pasteboard_string)));
         out_vector->length = length;
-        memset(out_vector->strings, 0, out_vector->length);
+        memset(out_vector->strings, 0, sizeof(struct wpe_pasteboard_string) * length);
 
         uint64_t i = 0;
         for (auto& entry : pasteboard)


### PR DESCRIPTION
The get_types() implementation has two flaws. First, the use of calloc()
is vulnerable to overflow if length is huge. Second, we attempt to zero
the allocation, but only zero the first element by mistake.

These issues were found by the Ubuntu Security Team. Thank you!