### PR TITLE
Wrap memory allocation functions to abort on failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(WPE_PUBLIC_HEADERS
 
 add_library(
     wpe
+    src/alloc.c
     src/input-xkb.c
     src/key-unicode.c
     src/pasteboard.c

--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,7 @@ if pkg_cflags.length() > 0
 endif
 
 libwpe = library('wpe-' + api_version,
+	'src/alloc.c',
 	'src/gamepad.c',
 	'src/input-xkb.c',
 	'src/key-unicode.c',

--- a/src/alloc-private.h
+++ b/src/alloc-private.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef wpe_alloc_private_h
+#define wpe_alloc_private_h
+
+#include <stdlib.h>
+
+#if defined(__has_attribute) && __has_attribute(noreturn)
+#define WPE_NORETURN __attribute__((noreturn))
+#else
+#define WPE_NORETURN
+#endif /* __has_attribute(noreturn) */
+
+#if defined(__has_attribute) && __has_attribute(alloc_size)
+#define WPE_ALLOCSIZE(...) __attribute__((alloc_size(__VA_ARGS__)))
+#else
+#define WPE_ALLOCSIZE(...)
+#endif /* __has_attribute(alloc_size) */
+
+#if defined(__has_attribute) && __has_attribute(malloc)
+#define WPE_MALLOC __attribute__((malloc))
+#else
+#define WPE_MALLOC
+#endif /* __has_attribute(malloc) */
+
+#if defined(__has_attribute) && __has_attribute(warn_unused_result)
+#define WPE_USERESULT __attribute__((warn_unused_result))
+#else
+#define WPE_USERESULT
+#endif /* __has_attribute(warn_unused_result) */
+
+#ifdef __cplusplus
+extern "C"
+#endif /* __cplusplus */
+    WPE_NORETURN void
+    wpe_alloc_fail(const char* file, unsigned line, size_t amount);
+
+WPE_ALLOCSIZE(1, 2)
+WPE_MALLOC WPE_USERESULT static inline void*
+wpe_calloc_impl(size_t nmemb, size_t size, const char* file, unsigned line)
+{
+    void* p = calloc(nmemb, size);
+    if (p)
+        return p;
+
+    wpe_alloc_fail(file, line, nmemb * size);
+}
+
+WPE_ALLOCSIZE(2)
+WPE_USERESULT static inline void*
+wpe_realloc_impl(void* p, size_t size, const char* file, unsigned line)
+{
+    if ((p = realloc(p, size)))
+        return p;
+
+    wpe_alloc_fail(file, line, size);
+}
+
+WPE_ALLOCSIZE(1)
+WPE_MALLOC WPE_USERESULT static inline void*
+wpe_malloc_impl(size_t size, const char* file, unsigned line)
+{
+    void* p = malloc(size);
+    if (p)
+        return p;
+
+    wpe_alloc_fail(file, line, size);
+}
+
+#define wpe_calloc(nmemb, size) wpe_calloc_impl((nmemb), (size), __FILE__, __LINE__)
+#define wpe_realloc(p, size)    wpe_realloc_impl((p), (size), __FILE__, __LINE__)
+#define wpe_malloc(size)        wpe_malloc_impl((size), __FILE__, __LINE__)
+#define wpe_free                free
+
+/* Prevent usage of unwrapped functions from this point onwards. */
+#pragma GCC poison malloc
+#pragma GCC poison realloc
+#pragma GCC poison calloc
+#pragma GCC poison free
+
+#undef WPE_ALLOCSIZE
+#undef WPE_MALLOC
+#undef WPE_NORETURN
+#undef WPE_USERESULT
+
+#endif /* wpe_alloc_private_h */

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, 2016, 2022 Igalia S.L.
+ * Copyright (C) 2022 Igalia S.L.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,22 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "renderer-host-private.h"
-
 #include "alloc-private.h"
-#include "loader-private.h"
 
-int
-wpe_renderer_host_create_client()
+#include <stdio.h>
+
+void
+wpe_alloc_fail(const char* file, unsigned line, size_t amount)
 {
-    static struct wpe_renderer_host* s_renderer_host = 0;
-    if (!s_renderer_host) {
-        s_renderer_host = wpe_calloc(1, sizeof(struct wpe_renderer_host));
-        s_renderer_host->base.interface = wpe_load_object("_wpe_renderer_host_interface");
-        s_renderer_host->base.interface_data = s_renderer_host->base.interface->create();
-
-        // FIXME: atexit() should clean up the object.
-    }
-
-    return s_renderer_host->base.interface->create_client(s_renderer_host->base.interface_data);
+    fprintf(stderr, "%s:%u: failed to allocate %zu bytes\n", file, line, amount);
+    fflush(stderr);
+    abort();
 }

--- a/src/gamepad.c
+++ b/src/gamepad.c
@@ -20,8 +20,8 @@
 
 #include "../include/wpe/gamepad.h"
 
+#include "alloc-private.h"
 #include <stdint.h>
-#include <stdlib.h>
 
 struct wpe_gamepad_provider {
     void*                                               backend;
@@ -44,10 +44,7 @@ wpe_gamepad_provider_create(void)
     if (!provider_interface)
         return NULL;
 
-    struct wpe_gamepad_provider* provider = calloc(1, sizeof(struct wpe_gamepad_provider));
-    if (!provider)
-        return NULL;
-
+    struct wpe_gamepad_provider* provider = wpe_calloc(1, sizeof(struct wpe_gamepad_provider));
     if (provider_interface->create)
         provider->backend = provider_interface->create(provider);
     return provider;
@@ -62,7 +59,7 @@ wpe_gamepad_provider_destroy(struct wpe_gamepad_provider* provider)
     if (provider_interface && provider_interface->destroy)
         provider_interface->destroy(provider->backend);
     provider->backend = NULL;
-    free(provider);
+    wpe_free(provider);
 }
 
 void
@@ -119,10 +116,7 @@ wpe_gamepad_create(unsigned gamepad_id)
     if (!gamepad_interface)
         return NULL;
 
-    struct wpe_gamepad* gamepad = calloc(1, sizeof(struct wpe_gamepad));
-    if (!gamepad)
-        return NULL;
-
+    struct wpe_gamepad* gamepad = wpe_calloc(1, sizeof(struct wpe_gamepad));
     if (gamepad_interface->create)
         gamepad->backend = gamepad_interface->create(gamepad, gamepad_id);
     return gamepad;
@@ -137,7 +131,7 @@ wpe_gamepad_destroy(struct wpe_gamepad* gamepad)
     if (gamepad_interface && gamepad_interface->destroy)
         gamepad_interface->destroy(gamepad->backend);
     gamepad->backend = NULL;
-    free(gamepad);
+    wpe_free(gamepad);
 }
 
 void

--- a/src/input-xkb.c
+++ b/src/input-xkb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, 2016 Igalia S.L.
+ * Copyright (C) 2015, 2016, 2022 Igalia S.L.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,10 +29,11 @@
 #include "../include/wpe/input-xkb.h"
 #include "../include/wpe/input.h"
 
+#include "alloc-private.h"
 #include <locale.h>
 #include <stdlib.h>
-#include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-compose.h>
+#include <xkbcommon/xkbcommon.h>
 
 struct wpe_input_xkb_context {
     struct xkb_context* context;
@@ -45,7 +46,7 @@ wpe_input_xkb_context_get_default()
 {
     static struct wpe_input_xkb_context* s_xkb_context = NULL;
     if (!s_xkb_context) {
-        s_xkb_context = calloc(1, sizeof(struct wpe_input_xkb_context));
+        s_xkb_context = wpe_calloc(1, sizeof(struct wpe_input_xkb_context));
         s_xkb_context->context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     }
 
@@ -231,7 +232,8 @@ wpe_input_xkb_context_get_entries_for_key_code(struct wpe_input_xkb_context* xkb
                     if (syms[sym] == key) {
                         if (++array_size > array_allocated_size) {
                             array_allocated_size += 4;
-                            array = (struct wpe_input_xkb_keymap_entry*)realloc(array, array_allocated_size * sizeof(struct wpe_input_xkb_keymap_entry));
+                            array =
+                                wpe_realloc(array, array_allocated_size * sizeof(struct wpe_input_xkb_keymap_entry));
                         }
                         struct wpe_input_xkb_keymap_entry* entry = &array[array_size - 1];
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, 2016 Igalia S.L.
+ * Copyright (C) 2015, 2016, 2022 Igalia S.L.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,9 +26,9 @@
 
 #include "loader-private.h"
 
+#include "alloc-private.h"
 #include <dlfcn.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 static void* s_impl_library = 0;
@@ -54,7 +54,7 @@ wpe_loader_set_impl_library_name(const char* impl_library_name)
         return;
 
     if (len > IMPL_LIBRARY_NAME_BUFFER_SIZE)
-        s_impl_library_name = (char *)malloc(len);
+        s_impl_library_name = wpe_malloc(len);
     else
         s_impl_library_name = s_impl_library_name_buffer;
     memcpy(s_impl_library_name, impl_library_name, len);

--- a/src/pasteboard-generic.cpp
+++ b/src/pasteboard-generic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, 2016 Igalia S.L.
+ * Copyright (C) 2015, 2016, 2022 Igalia S.L.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
 
 #include "pasteboard-private.h"
 
+#include "alloc-private.h"
 #include <cstdlib>
 #include <cstring>
 #include <map>
@@ -51,7 +52,8 @@ struct wpe_pasteboard_interface generic_pasteboard_interface = {
         if (!length)
             return;
 
-        out_vector->strings = static_cast<struct wpe_pasteboard_string*>(calloc(length, sizeof(struct wpe_pasteboard_string)));
+        out_vector->strings =
+            static_cast<struct wpe_pasteboard_string*>(wpe_calloc(length, sizeof(struct wpe_pasteboard_string)));
         out_vector->length = length;
         memset(out_vector->strings, 0, sizeof(struct wpe_pasteboard_string) * length);
 

--- a/src/pasteboard.c
+++ b/src/pasteboard.c
@@ -26,6 +26,7 @@
 
 #include "pasteboard-private.h"
 
+#include "alloc-private.h"
 #include "loader-private.h"
 #include <stdlib.h>
 #include <string.h>
@@ -36,7 +37,7 @@ wpe_pasteboard_string_initialize(struct wpe_pasteboard_string* string, const cha
     if (string->data)
         return;
 
-    string->data = calloc(in_length, sizeof(char));
+    string->data = wpe_calloc(in_length, sizeof(char));
     string->length = in_length;
     memcpy(string->data, in_string, in_length);
 }
@@ -44,8 +45,7 @@ wpe_pasteboard_string_initialize(struct wpe_pasteboard_string* string, const cha
 void
 wpe_pasteboard_string_free(struct wpe_pasteboard_string* string)
 {
-    if (string->data)
-        free((void*)string->data);
+    wpe_free(string->data);
     string->data = 0;
     string->length = 0;
 }
@@ -56,7 +56,7 @@ wpe_pasteboard_string_vector_free(struct wpe_pasteboard_string_vector* vector)
     if (vector->strings) {
         for (uint64_t i = 0; i < vector->length; ++i)
             wpe_pasteboard_string_free(&vector->strings[i]);
-        free(vector->strings);
+        wpe_free(vector->strings);
     }
     vector->strings = 0;
     vector->length = 0;
@@ -67,7 +67,7 @@ wpe_pasteboard_get_singleton()
 {
     static struct wpe_pasteboard* s_pasteboard = 0;
     if (!s_pasteboard) {
-        s_pasteboard = calloc(1, sizeof(struct wpe_pasteboard));
+        s_pasteboard = wpe_calloc(1, sizeof(struct wpe_pasteboard));
         s_pasteboard->interface = wpe_load_object("_wpe_pasteboard_interface");
         if (!s_pasteboard->interface)
             s_pasteboard->interface = &noop_pasteboard_interface;

--- a/src/renderer-backend-egl.c
+++ b/src/renderer-backend-egl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, 2016 Igalia S.L.
+ * Copyright (C) 2015, 2016, 2022 Igalia S.L.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,20 +26,18 @@
 
 #include "../include/wpe/renderer-backend-egl.h"
 
+#include "alloc-private.h"
 #include "loader-private.h"
 #include "renderer-backend-egl-private.h"
-#include <stdlib.h>
 
 struct wpe_renderer_backend_egl*
 wpe_renderer_backend_egl_create(int host_fd)
 {
-    struct wpe_renderer_backend_egl* backend = calloc(1, sizeof(struct wpe_renderer_backend_egl));
-    if (!backend)
-        return 0;
+    struct wpe_renderer_backend_egl* backend = wpe_calloc(1, sizeof(struct wpe_renderer_backend_egl));
 
     backend->base.interface = wpe_load_object("_wpe_renderer_backend_egl_interface");
     if (!backend->base.interface) {
-        free(backend);
+        wpe_free(backend);
         return 0;
     }
 
@@ -54,7 +52,7 @@ wpe_renderer_backend_egl_destroy(struct wpe_renderer_backend_egl* backend)
     backend->base.interface->destroy(backend->base.interface_data);
     backend->base.interface_data = 0;
 
-    free(backend);
+    wpe_free(backend);
 }
 
 EGLNativeDisplayType
@@ -74,13 +72,11 @@ wpe_renderer_backend_egl_get_platform(struct wpe_renderer_backend_egl* backend)
 struct wpe_renderer_backend_egl_target*
 wpe_renderer_backend_egl_target_create(int host_fd)
 {
-    struct wpe_renderer_backend_egl_target* target = calloc(1, sizeof(struct wpe_renderer_backend_egl_target));
-    if (!target)
-        return 0;
+    struct wpe_renderer_backend_egl_target* target = wpe_calloc(1, sizeof(struct wpe_renderer_backend_egl_target));
 
     target->base.interface = wpe_load_object("_wpe_renderer_backend_egl_target_interface");
     if (!target->base.interface) {
-        free(target);
+        wpe_free(target);
         return 0;
     }
 
@@ -98,7 +94,7 @@ wpe_renderer_backend_egl_target_destroy(struct wpe_renderer_backend_egl_target* 
     target->client = 0;
     target->client_data = 0;
 
-    free(target);
+    wpe_free(target);
 }
 
 void
@@ -148,13 +144,12 @@ wpe_renderer_backend_egl_target_deinitialize(struct wpe_renderer_backend_egl_tar
 struct wpe_renderer_backend_egl_offscreen_target*
 wpe_renderer_backend_egl_offscreen_target_create()
 {
-    struct wpe_renderer_backend_egl_offscreen_target* target = calloc(1, sizeof(struct wpe_renderer_backend_egl_offscreen_target));
-    if (!target)
-        return 0;
+    struct wpe_renderer_backend_egl_offscreen_target* target =
+        wpe_calloc(1, sizeof(struct wpe_renderer_backend_egl_offscreen_target));
 
     target->base.interface = wpe_load_object("_wpe_renderer_backend_egl_offscreen_target_interface");
     if (!target->base.interface) {
-        free(target);
+        wpe_free(target);
         return 0;
     }
 
@@ -169,7 +164,7 @@ wpe_renderer_backend_egl_offscreen_target_destroy(struct wpe_renderer_backend_eg
     target->base.interface->destroy(target->base.interface_data);
     target->base.interface_data = 0;
 
-    free(target);
+    wpe_free(target);
 }
 
 void

--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015, 2016 Igalia S.L.
+ * Copyright (C) 2015, 2016, 2022 Igalia S.L.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
 
 #include "view-backend-private.h"
 
+#include "alloc-private.h"
 #include "loader-private.h"
 #include <assert.h>
 #include <stdlib.h>
@@ -44,9 +45,7 @@ wpe_view_backend_create()
 struct wpe_view_backend*
 wpe_view_backend_create_with_backend_interface(struct wpe_view_backend_interface* interface, void* interface_user_data)
 {
-    struct wpe_view_backend* backend = calloc(1, sizeof(struct wpe_view_backend));
-    if (!backend)
-        return 0;
+    struct wpe_view_backend* backend = wpe_calloc(1, sizeof(struct wpe_view_backend));
 
     backend->base.interface = interface;
     backend->base.interface_data = backend->base.interface->create(interface_user_data, backend);
@@ -72,7 +71,7 @@ wpe_view_backend_destroy(struct wpe_view_backend* backend)
     backend->activity_state = 0;
     backend->refresh_rate = 0;
 
-    free(backend);
+    wpe_free(backend);
 }
 
 static void


### PR DESCRIPTION
Be consistent in handling memory allocation failures by always aborting execution. Previously, some call sites for `malloc`/`calloc`/`realloc` tried to handle allocation failures, but some others did not. Given that WebKit's FastMalloc will itself abort on allocation failures, doing the same in libwpe keeps behaviour consistent.

A new `alloc-private.h` header redefines the libc functions with `wpe_` prefixes, which perform checks after invoking the libc versions, and use a common `wpe_alloc_fail()`. The actual implementation is done through macros in order to pass along `__FILE__`/`__LINE__` to a set of inline functions defined directly in the header, in order to help out debug failures. As a bonus, GCC's `poison` pragma (supported by Clang, too) prevents accidental usage of the libc allocation functions.

As a side effect, simplify the call sites which attempted to handle failures, which now can assume that allocations never fail.

----

Fixes #112 