### PR TITLE
Fix build failure due to libc++ using libc functions

### DIFF
--- a/src/pasteboard-generic.cpp
+++ b/src/pasteboard-generic.cpp
@@ -26,11 +26,14 @@
 
 #include "pasteboard-private.h"
 
-#include "alloc-private.h"
-#include <cstdlib>
-#include <cstring>
 #include <map>
 #include <string>
+
+// We need to include this header last, in order to avoid template expansions
+// from the C++ standard library happening after it forbids usage of the libc
+// memory functions.
+#include "alloc-private.h"
+#include <cstring>
 
 namespace Generic {
 using Pasteboard = std::map<std::string, std::string>;


### PR DESCRIPTION
Include the `alloc-private.h` header after the C++ standard library headers. This sidesteps build failures caused by implementations of `std::map` and `std::string` which use libc memory allocation functions in expanded templates after they have been marked with the `poison` pragma.

Fixes #115