### PR TITLE
CI: Add job to run the Clang analyzer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,3 +132,48 @@ jobs:
       - name: Meson - Build
         run: |
           ninja -C _build
+  analyze:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: |
+          curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | \
+            sudo apt-key add -
+          sudo add-apt-repository \
+            'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
+          sudo apt update
+          sudo apt install -y flex libjson-glib-dev libxkbcommon-dev \
+            libegl1-mesa-dev libxml2-dev libxslt1-dev libyaml-dev llvm-14-dev \
+            libclang-14-dev libglib2.0-dev ninja-build clang-tools-14
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.6'
+      - name: Python Package Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install Python Packages
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install scan-build meson==0.55
+      - name: Configure
+        run: |
+          meson _work --prefix /usr -Dbuild-docs=false
+      - name: Analyze
+        run: |
+          analyze-build \
+            --enable-checker nullability.NullablePassedToNonnull \
+            --enable-checker optin.cplusplus.UninitializedObject \
+            --enable-checker optin.cplusplus.VirtualCall \
+            --enable-checker optin.performance.Padding \
+            --enable-checker optin.portability.UnixAPI \
+            --enable-checker valist.CopyToSelf \
+            --enable-checker valist.Uninitialized \
+            --enable-checker valist.Unterminated \
+            --cdb _work/compile_commands.json \
+            -o _work/report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Debian Packages
         run: |
           sudo apt update
@@ -24,11 +24,11 @@ jobs:
             libegl1-mesa-dev libxml2-dev libxslt1-dev libyaml-dev llvm-dev \
             libclang-dev libglib2.0-dev ninja-build
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: '3.6'
       - name: Python Package Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
@@ -52,7 +52,7 @@ jobs:
             > _work/meson/symbols
           (cd _work/meson/prefix && find lib -type f | sort) > _work/meson/files
       - name: Meson - Archive Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-meson
           path: _work/meson/prefix
@@ -71,7 +71,7 @@ jobs:
             > _work/cmake/symbols
           (cd _work/cmake/prefix && find lib -type f | sort) > _work/cmake/files
       - name: CMake - Archive Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-cmake
           path: _work/cmake/prefix
@@ -81,17 +81,17 @@ jobs:
           diff -u _work/{cmake,meson}/symbols
           diff -Naur _work/{cmake,meson}/prefix/usr/include/
       - name: Archive Documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs
           path: _work/cmake/build/Documentation/html
   publish:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Fetch Documentation
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docs
           path: html
@@ -107,13 +107,13 @@ jobs:
       PYTHONIOENCODING: "utf-8"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: '3.6'
       - name: Setup MSVC
-        uses: seanmiddleditch/gha-setup-vsdevenv@master
+        uses: seanmiddleditch/gha-setup-vsdevenv@v4
       - name: Install Tools
         run: |
           choco install winflexbison3 ninja -y --no-progress --stop-on-first-failure

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Head
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch Git History
         run: |
           git fetch --no-tags --prune --depth=1 \
@@ -24,7 +24,7 @@ jobs:
         run: |
           scripts/check-style -ocode-style.diff origin/master
       - name: Archive Diff
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: diff

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   format-cmake:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Adds one build job to the CI that runs the Clang analyzer. While at it, update the versions of actions used.