### PR TITLE
Fix build failure due to libc functions used in old glibc and libc++ headers

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -26,10 +26,11 @@
 
 #include "loader-private.h"
 
-#include "alloc-private.h"
 #include <dlfcn.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "alloc-private.h"
 
 static void* s_impl_library = 0;
 static struct wpe_loader_interface* s_impl_loader = 0;

--- a/src/pasteboard-generic.cpp
+++ b/src/pasteboard-generic.cpp
@@ -28,12 +28,12 @@
 
 #include <map>
 #include <string>
+#include <cstring>
 
 // We need to include this header last, in order to avoid template expansions
 // from the C++ standard library happening after it forbids usage of the libc
 // memory functions.
 #include "alloc-private.h"
-#include <cstring>
 
 namespace Generic {
 using Pasteboard = std::map<std::string, std::string>;

--- a/src/pasteboard.c
+++ b/src/pasteboard.c
@@ -26,10 +26,11 @@
 
 #include "pasteboard-private.h"
 
-#include "alloc-private.h"
 #include "loader-private.h"
 #include <stdlib.h>
 #include <string.h>
+
+#include "alloc-private.h"
 
 void
 wpe_pasteboard_string_initialize(struct wpe_pasteboard_string* string, const char* in_string, uint64_t in_length)


### PR DESCRIPTION
glibc < 2.26 uses calloc and malloc for the str(n)dup macros in bits/string2.h, included by string.h

libc++ cstdlib header can also use ::malloc, ::realloc, ::calloc and ::free

Fixes: 159851d069fe ("Wrap memory allocation functions to abort on failure")
Fixes: d77bc02f6b00 ("Fix build failure due to libc++ using libc functions")

This could be backported to 1.12 and 1.14 branches.