### PR TITLE
include string.h before poison pragma to avoid build issues on CentOS 7

### DIFF
--- a/src/alloc-private.h
+++ b/src/alloc-private.h
@@ -28,6 +28,7 @@
 #define wpe_alloc_private_h
 
 #include <stdlib.h>
+#include <string.h>
 
 #if defined(__has_attribute) && __has_attribute(noreturn)
 #define WPE_NORETURN __attribute__((noreturn))


### PR DESCRIPTION
include `string.h` before poisoning `{c,m}alloc` to avoid compilation issues on a CentOS 7 system:
```
225 /opt/apps/easybuild/software/GCCcore/11.3.0/bin/gcc -DWPE_COMPILATION -DWPE_ENABLE_XKB=1 -Dwpe_EXPORTS -I/tmp/jfg508/libwpe/1.13.3/GCCcore-11.3.0/libwpe-1.13.3/include -I/tmp/jfg508/libwpe/1.13.3/GCCcore-11.3.0/libwpe-1.13.3/src -O2 -ftree-vectorize -march=native -fno-math-errno -fPIC -Wall -O3 -DNDEBUG -fPIC -fvisibility=hidden -std=gnu99 -MD -MT CMakeFiles/wpe.dir/src/pasteboard.c.o -MF CMakeFiles/wpe.dir/src/pasteboard.c.o.d -o CMakeFiles/wpe.dir/src/pasteboard.c.o -c /tmp/jfg508/libwpe/1.13.3/GCCcore-11.3.0/libwpe-1.13.3/src/pasteboard.c
226 In file included from /usr/include/string.h:633,                                                                        
227                  from /tmp/jfg508/libwpe/1.13.3/GCCcore-11.3.0/libwpe-1.13.3/src/pasteboard.c:32:                       
228 /usr/include/bits/string2.h:1305:33: error: attempt to use poisoned "calloc"                                            
229  1305 |                      ? (char *) calloc ((size_t) 1, (size_t) 1)               \                                 
230       |                                 ^                                                                               
231 /usr/include/bits/string2.h:1307:53: error: attempt to use poisoned "malloc"                                            
232  1307 |                           char *__retval = (char *) malloc (__len);           \                                 
233       |                                                     ^                                                           
234 /usr/include/bits/string2.h:1325:33: error: attempt to use poisoned "calloc"                                            
235  1325 |                      ? (char *) calloc ((size_t) 1, (size_t) 1)               \                                 
236       |                                 ^                                                                               
237 /usr/include/bits/string2.h:1331:47: error: attempt to use poisoned "malloc"                                            
238  1331 |                           __retval = (char *) malloc (__len);                 \                                 
239       |                                               ^                                                                 
240 make[2]: *** [CMakeFiles/wpe.dir/src/pasteboard.c.o] Error 1  
```