### PR TITLE
ensure wpe input-xkb context returns NULL on error

### DIFF
--- a/src/input-xkb.c
+++ b/src/input-xkb.c
@@ -46,8 +46,11 @@ wpe_input_xkb_context_get_default()
 {
     static struct wpe_input_xkb_context* s_xkb_context = NULL;
     if (!s_xkb_context) {
-        s_xkb_context = wpe_calloc(1, sizeof(struct wpe_input_xkb_context));
-        s_xkb_context->context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+        struct xkb_context* context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+        if (context) {
+            s_xkb_context = wpe_calloc(1, sizeof(struct wpe_input_xkb_context));
+            s_xkb_context->context = context;
+        }
     }
 
     return s_xkb_context;


### PR DESCRIPTION
The `wpe_input_xkb_context_get_default` call manages a singleton WPE input (XKB) context for an implementer to easily fetch. However, if the underlying request of building an XKB context (`xkb_context_new`) fails, a singleton will be created with a managed `NULL` context. The only safe way for an implementer to utilize other WPE input calls is to call `wpe_input_xkb_context_get_context` and ensure the returned context is not `NULL` (a practice not really used). And even if there was a way to recover the environment to ensure `xkb_context_new` can return a value context, there is no way to rebuild the singleton.

To prevent such a state, this commit tweaks the
`wpe_input_xkb_context_get_default` call to only store/return a WPE input (XKB) context if the underlying XKB context could be created. This way, implements can know immediately when attempting to prepare WPE input if the environment does not supported input at this time.