### PR TITLE
Add keyboard modifiers for CAPS_LOCK and NUM_LOCK

### DIFF
--- a/include/wpe/input.h
+++ b/include/wpe/input.h
@@ -49,10 +49,12 @@ extern "C" {
 #endif
 
 enum wpe_input_modifier {
-    wpe_input_keyboard_modifier_control = 1 << 0,
-    wpe_input_keyboard_modifier_shift   = 1 << 1,
-    wpe_input_keyboard_modifier_alt     = 1 << 2,
-    wpe_input_keyboard_modifier_meta    = 1 << 3,
+    wpe_input_keyboard_modifier_control  = 1 << 0,
+    wpe_input_keyboard_modifier_shift    = 1 << 1,
+    wpe_input_keyboard_modifier_alt      = 1 << 2,
+    wpe_input_keyboard_modifier_meta     = 1 << 3,
+    wpe_input_keyboard_modifier_capslock = 1 << 4,
+    wpe_input_keyboard_modifier_numlock  = 1 << 5,
 
     wpe_input_pointer_modifier_button1  = 1 << 20,
     wpe_input_pointer_modifier_button2  = 1 << 21,

--- a/src/input-xkb.c
+++ b/src/input-xkb.c
@@ -163,6 +163,11 @@ wpe_input_xkb_context_get_modifiers(struct wpe_input_xkb_context* xkb_context, u
         retval |= wpe_input_keyboard_modifier_alt;
     if (mask & (1 << xkb_keymap_mod_get_index(keymap, "Meta")))
         retval |= wpe_input_keyboard_modifier_meta;
+    if (mask & (1 << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CAPS)))
+        retval |= wpe_input_keyboard_modifier_capslock;
+    if (mask & (1 << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_NUM)))
+        retval |= wpe_input_keyboard_modifier_numlock;
+
     return retval;
 }
 


### PR DESCRIPTION
Some Layout tests require managing the CAPS_LOCK key. For instance:

```
fast/events/dblclick-event-getModifierState.html
fast/events/special-key-events-in-input-text.html
fast/forms/caps-lock-indicator-width.html
```

Supporting CAPS_LOCK key (as well as NUM_LOCK) will require changes in Cog, wpebackend-fdo and the WPE part of WebKit.