### PR TITLE
fix: allow resetting fullscreen client to nullptr

### DIFF
--- a/include/wpe/view-backend.h
+++ b/include/wpe/view-backend.h
@@ -103,8 +103,8 @@ wpe_view_backend_set_input_client(struct wpe_view_backend*, const struct wpe_vie
 /**
  * wpe_view_backend_set_fullscreen_client:
  * @view_backend: (transfer none): The view backend to obtains events from.
- * @client: (transfer none): Client with callbacks for the events.
- * @userdata: (transfer none): User data passed to client callbacks.
+ * @client: (transfer none) (nullable): Client with callbacks for the events.
+ * @userdata: (transfer none) (nullable): User data passed to client callbacks.
  * 
  * Configure a @client with callbacks invoked for DOM fullscreen requests.
  * 

--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -103,8 +103,6 @@ wpe_view_backend_set_input_client(struct wpe_view_backend* backend, const struct
 void
 wpe_view_backend_set_fullscreen_client(struct wpe_view_backend* backend, const struct wpe_view_backend_fullscreen_client* client, void* client_data)
 {
-    assert(!backend->fullscreen_client);
-
     backend->fullscreen_client = client;
     backend->fullscreen_client_data = client_data;
 }


### PR DESCRIPTION
To avoid crashes like https://bugs.webkit.org/show_bug.cgi?id=264360 we need to reset wpe backend clients (see [this PR](https://github.com/WebKit/WebKit/pull/20123)) and the assert in `wpe_view_backend_set_fullscreen_client`did not allow that. 