### PR TITLE
CI: Update to use actions/{up,down}load-artifact v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             > _work/meson/symbols
           (cd _work/meson/prefix && find lib -type f | sort) > _work/meson/files
       - name: Meson - Archive Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-meson
           path: _work/meson/prefix
@@ -71,7 +71,7 @@ jobs:
             > _work/cmake/symbols
           (cd _work/cmake/prefix && find lib -type f | sort) > _work/cmake/files
       - name: CMake - Archive Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-cmake
           path: _work/cmake/prefix
@@ -81,7 +81,7 @@ jobs:
           diff -u _work/{cmake,meson}/symbols
           diff -Naur _work/{cmake,meson}/prefix/usr/include/
       - name: Archive Documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: _work/cmake/build/Documentation/html
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Fetch Documentation
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs
           path: html

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           scripts/check-style -ocode-style.diff origin/master
       - name: Archive Diff
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: diff


### PR DESCRIPTION
Update to v4 of the upload-artifact and download-artifact GitHub actions. The newer versions are faster, and v3 is going to be deprecated next November:

  https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/