### PR TITLE
gamepad: fix ABI break in wpe_gamepad_client_interface

### DIFF
--- a/include/wpe/gamepad.h
+++ b/include/wpe/gamepad.h
@@ -145,7 +145,6 @@ struct wpe_gamepad_client_interface {
     /*< private >*/
     void (*_wpe_reserved1)(void);
     void (*_wpe_reserved2)(void);
-    void (*_wpe_reserved3)(void);
 };
 
 /**


### PR DESCRIPTION
In #134, the `analog_button_changed field` was added to `wpe_gamepad_client_interface`, but it missed removing one of trailing reserved fields, so the struct size grew and broke upstream WPE build in developer mode:

```
GamepadLibWPE.cpp:62:5: error: missing field '_wpe_reserved3' initializer [-Werror,-Wmissing-field-initializers]
```